### PR TITLE
ci(.github): use ACTIONS_TOKEN instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,4 +24,4 @@ jobs:
     - name: Test with pytest
       run: uv run --python ${{ matrix.python-version }} pytest
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}


### PR DESCRIPTION
## Summary

- ci(test): use ACTIONS_TOKEN instead of GITHUB_TOKEN

## Changed files

**Modified**
- `.github/workflows/test.yaml` (+1/-1)

## Commits

- 30f128b ci(test): use ACTIONS_TOKEN instead of GITHUB_TOKEN