### PR TITLE
fix: change workflow glob pattern from .yml to .yaml

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,3 +24,11 @@ jobs:
       run: uv run ty check
     - name: Analyze Dependencies
       run: uv run deptry .
+    - name: Check workflow templates use .yaml extension
+      run: |
+        yml_files=$(find github_rest_api/scripts/github/workflows/ -name '*.yml')
+        if [ -n "$yml_files" ]; then
+          echo "The following workflow templates must use the .yaml extension instead of .yml:"
+          echo "$yml_files"
+          exit 1
+        fi

--- a/github_rest_api/scripts/github/create_github_repo.py
+++ b/github_rest_api/scripts/github/create_github_repo.py
@@ -80,7 +80,7 @@ def _init_local_repo(
     _add_workflow(path, language)
 
 
-def add_github_repo(
+def create_github_repo(
     repo: str,
     private: bool,
     language: str,
@@ -131,7 +131,7 @@ def _add_workflow(path: Path, language: str, workflow_dir: Path | None = None) -
 
 
 def parse_args(args=None, namespace=None):
-    parser = argparse.ArgumentParser(description="Add a GitHub repository.")
+    parser = argparse.ArgumentParser(description="Create a GitHub repository.")
     parser.add_argument(
         "repo",
         help="The GitHub repo (in the format of owner/repo) to be created.",
@@ -203,7 +203,7 @@ def parse_args(args=None, namespace=None):
 def main() -> int:
     args = parse_args()
     try:
-        add_github_repo(
+        create_github_repo(
             repo=args.repo,
             private=args.private,
             language=args.language,

--- a/github_rest_api/scripts/github/create_github_repo.py
+++ b/github_rest_api/scripts/github/create_github_repo.py
@@ -117,7 +117,7 @@ def _add_workflow(path: Path, language: str, workflow_dir: Path | None = None) -
         workflow_dir = Path(__file__).parent / "workflows"
     dir_dest = path / ".github" / "workflows"
     dir_dest.mkdir(parents=True, exist_ok=True)
-    for yaml in workflow_dir.glob("*.yml"):
+    for yaml in workflow_dir.glob("*.yaml"):
         if not (dir_dest / yaml.name).exists():
             shutil.copy2(yaml, dir_dest)
     if not language:
@@ -125,7 +125,7 @@ def _add_workflow(path: Path, language: str, workflow_dir: Path | None = None) -
     lang_dir = workflow_dir / language
     if not lang_dir.exists():
         return
-    for yaml in lang_dir.glob("*.yml"):
+    for yaml in lang_dir.glob("*.yaml"):
         if not (dir_dest / yaml.name).exists():
             shutil.copy2(yaml, dir_dest)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "github-rest-api"
-version = "0.45.0"
+version = "0.46.0"
 description = "Simple wrapper of GitHub REST APIs."
 readme = "README.md"
 authors = [ { name = "Ben Du", email = "longendu@yahoo.com" } ]
@@ -27,10 +27,10 @@ dependencies = [
 optional-dependencies.ai = [
   "litellm>=1.50",
 ]
-scripts.create_github_repo = "github_rest_api.scripts.github.create_github_repo:main"
 scripts.auto_merge_pull_request = "github_rest_api.scripts.github.auto_merge_pull_request:main"
 scripts.build_container_images = "github_rest_api.scripts.container.build_container_images:main"
 scripts.config_container = "github_rest_api.scripts.container.config_container:main"
+scripts.create_github_repo = "github_rest_api.scripts.github.create_github_repo:main"
 scripts.create_pull_request = "github_rest_api.scripts.github.create_pull_request:main"
 scripts.release_on_github = "github_rest_api.scripts.github.release_on_github:main"
 scripts.remove_branch = "github_rest_api.scripts.github.remove_branch:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 optional-dependencies.ai = [
   "litellm>=1.50",
 ]
-scripts.add_github_repo = "github_rest_api.scripts.github.add_github_repo:main"
+scripts.create_github_repo = "github_rest_api.scripts.github.create_github_repo:main"
 scripts.auto_merge_pull_request = "github_rest_api.scripts.github.auto_merge_pull_request:main"
 scripts.build_container_images = "github_rest_api.scripts.container.build_container_images:main"
 scripts.config_container = "github_rest_api.scripts.container.config_container:main"

--- a/uv.lock
+++ b/uv.lock
@@ -542,7 +542,7 @@ wheels = [
 
 [[package]]
 name = "github-rest-api"
-version = "0.45.0"
+version = "0.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "dulwich" },


### PR DESCRIPTION
## Summary

- refactor(scripts): rename add_github_repo to create_github_repo
- fix(scripts): change workflow glob pattern from .yml to .yaml
- chore: bump version to 0.46.0

## Changed files

**Modified**
- `pyproject.toml` (+2/-2)
- `uv.lock` (+1/-1)
**Renamed**
- `github_rest_api/scripts/github/create_github_repo.py` (+5/-5)

## Commits

- 6a9bfb8 refactor(scripts): rename add_github_repo to create_github_repo
- 4c0a125 fix(scripts): change workflow glob pattern from .yml to .yaml
- fcdf644 chore: bump version to 0.46.0