### PR TITLE
fix: simplify auto-merge marker format to plain text

### DIFF
--- a/github_rest_api/github.py
+++ b/github_rest_api/github.py
@@ -31,7 +31,7 @@ DEFAULT_PR_MODEL = "anthropic/claude-haiku-4-5-20251001"
 # Defaults for automatic pull request merging (see Repository.auto_merge_pull_requests).
 # A marker comment from an allowlisted approver is accepted as an approval signal
 # for AI reviewers that only comment instead of submitting a formal review.
-DEFAULT_AUTO_MERGE_MARKER = "<!-- auto-merge: approved -->"
+DEFAULT_AUTO_MERGE_MARKER = "AUTO_MERGE_APPROVED"
 # Conventional-commit title types eligible for auto-merge.
 DEFAULT_AUTO_MERGE_TYPES = ("chore", "docs", "deps")
 # A PR is only auto-merged once its head commit is at least this old, an anti-race

--- a/github_rest_api/github.py
+++ b/github_rest_api/github.py
@@ -177,8 +177,15 @@ def _field_gate_failure(
         return "it is a draft"
     if not _in_allowlist(_login(pr), _normalized_logins(authors)):
         return "its author is not in the allowlist"
-    if not _title_type_allowed(pr.get("title") or "", allowed_types):
-        return "its title type is not auto-merge eligible"
+    title = pr.get("title") or ""
+    if not _title_type_allowed(title, allowed_types):
+        type_ = _conventional_type(title)
+        current = f"'{type_}'" if type_ is not None else "missing/unrecognized"
+        eligible = ", ".join(allowed_types) or "none"
+        return (
+            f"its title type ({current}) is not auto-merge eligible "
+            f"(eligible types: {eligible})"
+        )
     return None
 
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -525,7 +525,7 @@ def test_should_auto_merge_marker_comment_path():
         comments=[
             {
                 "user": {"login": "bot"},
-                "body": "<!-- auto-merge: approved -->",
+                "body": "AUTO_MERGE_APPROVED",
                 # Posted after the head commit (which _auto_merge_repo dates 30 min ago).
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
@@ -543,7 +543,7 @@ def test_should_auto_merge_skips_marker_comment_before_head_commit():
         comments=[
             {
                 "user": {"login": "bot"},
-                "body": "<!-- auto-merge: approved -->",
+                "body": "AUTO_MERGE_APPROVED",
                 "created_at": (
                     datetime.now(timezone.utc) - timedelta(hours=1)
                 ).isoformat(),
@@ -593,7 +593,7 @@ def test_should_auto_merge_changes_requested_vetoes_marker_comment():
     # left an approving marker comment.
     repo, patches = _auto_merge_repo(
         reviews=[_review("bot", "CHANGES_REQUESTED")],
-        comments=[{"user": {"login": "bot"}, "body": "<!-- auto-merge: approved -->"}],
+        comments=[{"user": {"login": "bot"}, "body": "AUTO_MERGE_APPROVED"}],
     )
     assert _run_should_auto_merge(repo, patches) is None
 


### PR DESCRIPTION
## Summary

- fix: simplify auto-merge marker format to plain text
- fix: include title type details in auto-merge eligibility error message

## Changed files

**Modified**
- `github_rest_api/github.py` (+10/-3)
- `tests/test_github.py` (+3/-3)

## Commits

- 8eb9942 fix: simplify auto-merge marker format to plain text
- e513308 fix: include title type details in auto-merge eligibility error message