### PR TITLE
ci(.github): fix auto-merge workflow event trigger

### DIFF
--- a/.github/workflows/auto_merge_pull_request.yaml
+++ b/.github/workflows/auto_merge_pull_request.yaml
@@ -1,31 +1,81 @@
 name: Auto Merge PR
 on:
+  # The Claude review runs with `track_progress`, which creates its tracking
+  # comment when the review *starts* and then edits that same comment as the
+  # review progresses. The AUTO_MERGE_APPROVED marker therefore lands via an
+  # edit, so `issue_comment: created` fires far too early (the head commit is
+  # still seconds old and the marker is not written yet). Waiting for the review
+  # workflow to complete is what reliably lands after the marker exists and
+  # after the head-commit age gate has been cleared. The other PR checks
+  # are listed too because the merge gate additionally needs `mergeable_state
+  # == clean`, i.e. every check green -- whichever check finishes last is the
+  # one that makes the PR mergeable, and that is not always the review.
+  # Renaming any of these silently disables the trigger.
+  workflow_run:
+    workflows:
+      - Claude Code Review
+      - Lint Code
+      - Run Tests
+    types:
+      - completed
+  # Kept for approvals that come from a human rather than from Claude.
+  #
+  # `issue_comment: created` is deliberately absent: the only comment created on
+  # a PR here is the review's tracking comment, created seconds after the push,
+  # when the head commit is still under the age gate and the marker has not been
+  # written. It fired on every PR and could never merge anything. A marker typed
+  # by hand is picked up by the cron, or immediately via `workflow_dispatch`.
   pull_request_review:
     types:
       - submitted
-  issue_comment:
-    types:
-      - created
-  check_suite:
-    types:
-      - completed
+  # Backstop for anything the event triggers miss.
   schedule:
     - cron: '0 * * * *'
       timezone: 'America/Los_Angeles'
+  # Manual escape hatch. Run with `dry_run` to have the tool log its per-PR
+  # `Skipping auto-merge of PR #N: <reason>` verdicts without merging anything,
+  # which is the fastest way to diagnose why a PR is not being picked up.
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Log eligible PRs without merging them
+        type: boolean
+        default: false
 permissions:
   contents: write
   pull-requests: write
+concurrency:
+  # Every run rescans all open PRs, so overlapping runs are pure duplicate work
+  # and the newest run always sees the freshest state. Do not cancel in
+  # progress: a run cancelled midway through the merge API call is worse than a
+  # redundant one.
+  group: auto-merge-pull-request
+  cancel-in-progress: false
 jobs:
   auto_merge_pull_request:
+    # A triggering workflow that failed, was cancelled or was skipped left the
+    # PR unmergeable or wrote no marker, so there is nothing new to act on.
+    # This job checks out no PR code, so the elevated `workflow_run` context is
+    # never exposed to PR-controlled input.
+    if: |
+      github.event_name != 'workflow_run'
+      || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    # The concurrency group above serializes every run, so a hung run would
+    # block all merges until the default 6h timeout.
+    timeout-minutes: 10
     steps:
       - name: Install uv
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sudo env UV_INSTALL_DIR="/usr/local/bin" sh
       - name: Auto Merge PR
+        # `--allowed-types` is intentionally left at the upstream default
+        # (build, chore, ci, docs, deps) so that only simple PRs auto-merge;
+        # anything substantive, `feat` and `fix` included, is merged by hand.
         run: |
           uvx --from github-rest-api@latest auto_merge_pull_request \
             --authors dclong \
             --approvers dclong 'claude[bot]' 'gemini-code-assist[bot]' \
             --marker 'AUTO_MERGE_APPROVED' \
+            ${{ inputs.dry_run && '--dry-run' || '' }} \
             --token ${{ secrets.ACTIONS_TOKEN }}


### PR DESCRIPTION
## Summary

- ci: fix auto-merge workflow event trigger

## Changed files

**Modified**
- `.github/workflows/auto_merge_pull_request.yaml` (+56/-6)

## Commits

- 2a13e94 ci: fix auto-merge workflow event trigger