### PR TITLE
fix: support creating branches when HEAD is detached

### DIFF
--- a/github_rest_api/scripts/github/create_github_repo.py
+++ b/github_rest_api/scripts/github/create_github_repo.py
@@ -10,6 +10,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from dulwich import porcelain
+from dulwich.refs import HEADREF
 
 from github_rest_api import Organization, User
 from github_rest_api.utils import as_str_sequence
@@ -56,10 +57,19 @@ def _active_branch(path: Path) -> str:
         return porcelain.active_branch(path).decode()
     except (IndexError, ValueError) as e:
         raise ValueError(
-            f"HEAD of the local repo at '{path}' is detached (not on any branch), "
-            "which is unsupported (this happens, e.g., with a colocated Jujutsu repo). "
+            f"Cannot determine the initial branch of the local repo at '{path}' "
+            "as HEAD does not point at a branch. "
             "Check out a branch (e.g. `git switch -c main`) before running this command."
         ) from e
+
+
+def _head_commit(path: Path) -> str | None:
+    """Resolve HEAD to a commit SHA, or None if HEAD does not resolve to one."""
+    with porcelain.open_repo_closing(path) as repo:
+        try:
+            return repo.refs[HEADREF].decode()
+        except KeyError:
+            return None
 
 
 def _init_local_repo(
@@ -84,7 +94,9 @@ def _init_local_repo(
     if not (path / ".git").exists():
         porcelain.init(path=path)
         logger.info("Initialized empty Git repository in %s", path)
-    if not porcelain.branch_list(path):
+    head = _head_commit(path)
+    if head is None and not porcelain.branch_list(path):
+        # A brand new repository: no commit and no branch yet.
         initial_branch = _active_branch(path)
         porcelain.add(repo=path, paths=["README.md"])
         logger.info("Added README.md to staging")
@@ -101,9 +113,13 @@ def _init_local_repo(
             logger.info("Deleted initial branch '%s'", initial_branch)
     else:
         existing_branches = {b.decode() for b in porcelain.branch_list(path)}
+        # Point new branches at HEAD's commit explicitly. Dulwich fails to resolve
+        # its default "HEAD" objectish when HEAD is detached, which is the normal
+        # state of a colocated Jujutsu repository. (When HEAD is unborn, head is
+        # None and dulwich falls back to that "HEAD" default.)
         for branch in branches:
             if branch not in existing_branches:
-                porcelain.branch_create(repo=path, name=branch)
+                porcelain.branch_create(repo=path, name=branch, objectish=head)
                 logger.info("Created branch '%s' from HEAD", branch)
     _ensure_remote(path, repo, protocol)
     if push:

--- a/tests/test_create_github_repo.py
+++ b/tests/test_create_github_repo.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+import pytest
+from dulwich import porcelain
+from dulwich.refs import HEADREF
+
+from github_rest_api.scripts.github.create_github_repo import _init_local_repo
+
+KEPT_BRANCH = "kept"
+
+
+@pytest.fixture(autouse=True)
+def isolated_git_config(tmp_path, monkeypatch):
+    """Ignore the ambient Git config, e.g. commit.gpgsign or init.defaultBranch."""
+    config = tmp_path / "gitconfig"
+    config.touch()
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(config))
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.delenv("GIT_CONFIG_SYSTEM", raising=False)
+
+
+def _init_local(dir_: Path, branches=("main",)) -> None:
+    _init_local_repo(
+        repo="owner/name",
+        language="",
+        dir_=str(dir_),
+        token="",
+        protocol="git",
+        push=False,
+        branches=branches,
+    )
+
+
+def _branches(dir_: Path) -> set[str]:
+    return {b.decode() for b in porcelain.branch_list(dir_)}
+
+
+def _head(dir_: Path) -> bytes:
+    return (dir_ / ".git" / "HEAD").read_bytes().strip()
+
+
+def _detached_repo(dir_: Path, keep_branch: bool) -> bytes:
+    """Build a repo whose HEAD is detached, as in a colocated Jujutsu repo."""
+    dir_.mkdir()
+    porcelain.init(path=dir_)
+    (dir_ / "code.py").write_text("print('hello')\n")
+    porcelain.add(repo=dir_, paths=["code.py"])
+    porcelain.commit(repo=dir_, message="first commit")
+    initial_branch = porcelain.active_branch(dir_).decode()
+    with porcelain.open_repo_closing(dir_) as repo:
+        head = repo.refs[HEADREF]
+    if keep_branch:
+        # An explicit name, so that the test does not depend on the initial one.
+        porcelain.branch_create(repo=dir_, name=KEPT_BRANCH)
+    (dir_ / ".git" / "HEAD").write_bytes(head + b"\n")  # Detach HEAD at the commit.
+    porcelain.branch_delete(repo=dir_, name=initial_branch)
+    return head
+
+
+def test_init_local_repo_from_scratch(tmp_path):
+    dir_ = tmp_path / "repo"
+    _init_local(dir_, branches=("main", "dev"))
+    assert _branches(dir_) == {"main", "dev"}
+    assert porcelain.active_branch(dir_).decode() == "main"
+    assert (dir_ / "README.md").exists()
+
+
+def test_init_local_repo_with_detached_head(tmp_path):
+    dir_ = tmp_path / "repo"
+    head = _detached_repo(dir_, keep_branch=False)
+    assert not _branches(dir_)
+
+    _init_local(dir_, branches=("main", "dev"))
+
+    assert _branches(dir_) == {"main", "dev"}
+    with porcelain.open_repo_closing(dir_) as repo:
+        assert repo.refs[b"refs/heads/main"] == head
+        assert repo.refs[b"refs/heads/dev"] == head
+    # HEAD is left detached rather than checked out onto a new branch.
+    assert _head(dir_) == head
+
+
+def test_init_local_repo_with_detached_head_and_existing_branch(tmp_path):
+    dir_ = tmp_path / "repo"
+    head = _detached_repo(dir_, keep_branch=True)
+    assert _branches(dir_) == {KEPT_BRANCH}
+
+    _init_local(dir_, branches=("main",))
+
+    assert _branches(dir_) == {KEPT_BRANCH, "main"}
+    with porcelain.open_repo_closing(dir_) as repo:
+        assert repo.refs[b"refs/heads/main"] == head
+        assert repo.refs[b"refs/heads/" + KEPT_BRANCH.encode()] == head
+    assert _head(dir_) == head


### PR DESCRIPTION
## Summary

- fix: support creating branches when HEAD is detached

## Changed files

**Added**
- `tests/test_create_github_repo.py` (+94/-0)
**Modified**
- `github_rest_api/scripts/github/create_github_repo.py` (+20/-4)

## Commits

- d8f6872 fix: support creating branches when HEAD is detached