### PR TITLE
feat: add IssueStateReason enum and milestone support for issues

### DIFF
--- a/github_rest_api/__init__.py
+++ b/github_rest_api/__init__.py
@@ -1,19 +1,27 @@
 """GitHub REST APIs."""
 
 from .github import (
+    UNSET,
+    IssueState,
+    IssueStateReason,
     MergeMethod,
     Organization,
     Repository,
     RepositoryType,
     SecretVisibility,
+    Unset,
     User,
 )
 
 __all__ = [
+    "UNSET",
+    "IssueState",
+    "IssueStateReason",
     "MergeMethod",
     "Organization",
     "Repository",
     "RepositoryType",
     "SecretVisibility",
+    "Unset",
     "User",
 ]

--- a/github_rest_api/github.py
+++ b/github_rest_api/github.py
@@ -442,10 +442,54 @@ class IssueState(StrEnum):
     ALL = "all"
 
 
+class IssueStateReason(StrEnum):
+    """Why an issue was closed or reopened, accompanying an ``IssueState``."""
+
+    COMPLETED = "completed"
+    NOT_PLANNED = "not_planned"
+    DUPLICATE = "duplicate"
+    REOPENED = "reopened"
+
+
 class MergeMethod(StrEnum):
     MERGE = "merge"
     SQUASH = "squash"
     REBASE = "rebase"
+
+
+class Unset:
+    """The type of :data:`UNSET`."""
+
+    def __repr__(self) -> str:
+        return "UNSET"
+
+
+# Sentinel marking an update field the caller did not mention, so that a field
+# left out is distinguishable from one explicitly set to an empty/null value.
+# `None` cannot serve as that marker because GitHub gives it a meaning of its
+# own: `{"milestone": None}` detaches the milestone, while omitting the key
+# leaves it alone. See `Repository.update_issue`.
+UNSET = Unset()
+
+
+def _validate_issue_state(state: str, noun: str = "issue") -> None:
+    """Validate a state an issue or milestone can be *set* to.
+
+    ``IssueState.ALL`` is a filter for listing, not a state anything can hold;
+    GitHub rejects it with a 422. It is caught here so the mistake is reported
+    against the argument rather than as an opaque HTTP error.
+
+    :param state: The state to set (``open`` or ``closed``).
+    :param noun: What is being updated, for the error message.
+    :raises ValueError: If the state is anything other than open or closed.
+    """
+    if state not in (IssueState.OPEN, IssueState.CLOSED):
+        # `str(state)` so a StrEnum renders as 'all' rather than
+        # <IssueState.ALL: 'all'>, matching how a plain string argument reads.
+        raise ValueError(
+            f"Invalid {noun} state {str(state)!r}: a {noun} can only be set to "
+            f"'{IssueState.OPEN}' or '{IssueState.CLOSED}'."
+        )
 
 
 class Repository(GitHub):
@@ -465,6 +509,10 @@ class Repository(GitHub):
         self._url_branches = f"{self._url_repo}/branches"
         self._url_refs = f"{self._url_repo}/git/refs"
         self._url_issues = f"{self._url_repo}/issues"
+        # Issue comments are edited/deleted by comment id, not issue number, so
+        # this endpoint is not nested under a specific issue.
+        self._url_issue_comments = f"{self._url_issues}/comments"
+        self._url_milestones = f"{self._url_repo}/milestones"
         self._url_releases = f"{self._url_repo}/releases"
         self._url_secrets = f"{self._url_repo}/actions/secrets"
         self._url_compare = f"{self._url_repo}/compare"
@@ -548,6 +596,28 @@ class Repository(GitHub):
         :param n: The maximum number of reviews to return (0 means all).
         """
         return self._extract_all(url=f"{self._url_pull}/{pr_number}/reviews", n=n)
+
+    def get_pull_request_review_comments(
+        self, pr_number: int, n: int = 0
+    ) -> list[dict[str, Any]]:
+        """List the review comments on a pull request.
+
+        These are the line-anchored comments left on the diff, each carrying
+        ``path``, ``line``/``original_line`` and ``diff_hunk``, and grouped into
+        threads via ``in_reply_to_id``. They are a different resource from the
+        conversation-level comments returned by ``get_issue_comments``, which the
+        pull request shares with its issue; a full picture of a PR's discussion
+        needs both.
+
+        Every review comment is listed, whether it belongs to a submitted review
+        or was posted as a standalone comment. Comments still pending in an
+        unsubmitted review are not visible to anyone but their author, so they
+        are absent.
+
+        :param pr_number: The number of the pull request.
+        :param n: The maximum number of review comments to return (0 means all).
+        """
+        return self._extract_all(url=f"{self._url_pull}/{pr_number}/comments", n=n)
 
     def get_issues(
         self, state: IssueState = IssueState.OPEN, n: int = 0
@@ -642,7 +712,7 @@ class Repository(GitHub):
     def merge_pull_request(
         self,
         pr_number: int,
-        merge_method: MergeMethod | str = MergeMethod.MERGE,
+        merge_method: MergeMethod = MergeMethod.MERGE,
         sha: str = "",
     ) -> dict[str, Any]:
         """Merge a pull request in this repository.
@@ -706,9 +776,9 @@ class Repository(GitHub):
         self,
         pr_number: int,
         *,
-        authors: Sequence[str],
-        approvers: Sequence[str],
-        allowed_types: Sequence[str] = DEFAULT_AUTO_MERGE_TYPES,
+        authors: str | Sequence[str],
+        approvers: str | Sequence[str],
+        allowed_types: str | Sequence[str] = DEFAULT_AUTO_MERGE_TYPES,
         min_age_minutes: int = DEFAULT_MIN_AGE_MINUTES,
         marker: str = DEFAULT_AUTO_MERGE_MARKER,
     ) -> str | None:
@@ -731,9 +801,12 @@ class Repository(GitHub):
         the first failure so extra requests are avoided.
 
         :param pr_number: The number of the pull request.
-        :param authors: Logins whose PRs are eligible for auto-merge.
-        :param approvers: Logins whose reviews/marker comments grant approval.
-        :param allowed_types: Conventional-Commits title types eligible for auto-merge.
+        :param authors: Logins whose PRs are eligible for auto-merge, or a
+            single login as a bare string.
+        :param approvers: Logins whose reviews/marker comments grant approval,
+            or a single login as a bare string.
+        :param allowed_types: Conventional-Commits title types eligible for
+            auto-merge, or a single type as a bare string.
         :param min_age_minutes: The minimum head-commit age in minutes.
         :param marker: The marker substring an approver may comment to approve.
         :return: The validated head SHA when the PR is eligible, else ``None``.
@@ -782,20 +855,23 @@ class Repository(GitHub):
     def auto_merge_pull_requests(
         self,
         *,
-        authors: Sequence[str],
-        approvers: Sequence[str],
-        allowed_types: Sequence[str] = DEFAULT_AUTO_MERGE_TYPES,
+        authors: str | Sequence[str],
+        approvers: str | Sequence[str],
+        allowed_types: str | Sequence[str] = DEFAULT_AUTO_MERGE_TYPES,
         min_age_minutes: int = DEFAULT_MIN_AGE_MINUTES,
         marker: str = DEFAULT_AUTO_MERGE_MARKER,
-        merge_method: MergeMethod | str = MergeMethod.MERGE,
+        merge_method: MergeMethod = MergeMethod.MERGE,
         dry_run: bool = False,
     ) -> list[int]:
         """Auto-merge every open pull request that passes ``should_auto_merge``.
 
-        :param authors: Logins whose PRs are eligible for auto-merge. An empty
-            allowlist makes nothing eligible (fail-safe).
-        :param approvers: Logins whose reviews/marker comments grant approval.
-        :param allowed_types: Conventional-Commits title types eligible for auto-merge.
+        :param authors: Logins whose PRs are eligible for auto-merge, or a
+            single login as a bare string. An empty allowlist makes nothing
+            eligible (fail-safe).
+        :param approvers: Logins whose reviews/marker comments grant approval,
+            or a single login as a bare string.
+        :param allowed_types: Conventional-Commits title types eligible for
+            auto-merge, or a single type as a bare string.
         :param min_age_minutes: The minimum head-commit age in minutes.
         :param marker: The marker substring an approver may comment to approve.
         :param merge_method: The merge method to use (``merge``, ``squash`` or
@@ -991,8 +1067,9 @@ class Repository(GitHub):
         self,
         title: str,
         body: str = "",
-        labels: Sequence[str] = (),
-        assignees: Sequence[str] = (),
+        labels: str | Sequence[str] = (),
+        assignees: str | Sequence[str] = (),
+        milestone: int | None = None,
     ) -> dict[str, Any]:
         """Create an issue in this repository.
 
@@ -1005,6 +1082,9 @@ class Repository(GitHub):
         :param assignees: Logins of users to assign to the new issue, or a
             single login as a bare string. Silently dropped unless the
             authenticated user has push access to the repository.
+        :param milestone: The number of the milestone to associate the new issue
+            with (see ``get_milestones``). Silently dropped unless the
+            authenticated user has push access to the repository.
         """
         labels = as_str_sequence(labels)
         assignees = as_str_sequence(assignees)
@@ -1015,7 +1095,356 @@ class Repository(GitHub):
             json["labels"] = list(labels)
         if assignees:
             json["assignees"] = list(assignees)
+        if milestone is not None:
+            json["milestone"] = milestone
         return self._post(url=self._url_issues, json=json).json()
+
+    def get_issue(self, issue_number: int) -> dict[str, Any]:
+        """Get a single issue in this repository.
+
+        :param issue_number: The number of the issue. A pull request number is
+            also accepted, since GitHub models pull requests as issues; the
+            payload then carries a ``pull_request`` key.
+        """
+        return self._get(url=f"{self._url_issues}/{issue_number}").json()
+
+    def update_issue(
+        self,
+        issue_number: int,
+        *,
+        title: str | Unset = UNSET,
+        body: str | Unset = UNSET,
+        state: IssueState | Unset = UNSET,
+        state_reason: IssueStateReason | None | Unset = UNSET,
+        duplicate_issue_id: int | Unset = UNSET,
+        labels: str | Sequence[str] | Unset = UNSET,
+        assignees: str | Sequence[str] | Unset = UNSET,
+        milestone: int | None | Unset = UNSET,
+    ) -> dict[str, Any]:
+        """Update an issue in this repository.
+
+        Only the fields passed are sent, so an update never disturbs a field the
+        caller did not mention. That distinction is what the ``UNSET`` default
+        buys: ``None`` and the empty sequence are meaningful values here (they
+        detach the milestone and clear the labels/assignees respectively), so
+        they cannot double as "leave this alone".
+
+        ``labels`` and ``assignees`` replace the existing set rather than adding
+        to it; to add or remove a few entries without knowing the rest, use
+        ``add_issue_labels``/``remove_issue_label`` or
+        ``add_issue_assignees``/``remove_issue_assignees``.
+
+        :param issue_number: The number of the issue.
+        :param title: A new title.
+        :param body: A new Markdown body; pass ``""`` to empty it.
+        :param state: ``open`` or ``closed`` (see also ``close_issue``).
+        :param state_reason: Why the issue is in that state (``completed``,
+            ``not_planned``, ``duplicate`` or ``reopened``), or None to clear it.
+            It must be passed alongside ``state``, and GitHub applies it only
+            when the state actually changes: re-closing an already-closed issue
+            keeps the reason it was closed with.
+        :param duplicate_issue_id: The id (not the number) of the issue this one
+            duplicates. GitHub requires it when ``state_reason`` is ``duplicate``
+            and ignores it otherwise, so the two must be passed together.
+        :param labels: Names of the labels the issue should carry, replacing any
+            current ones; a bare string is one label, and an empty sequence
+            clears them all. Labels that do not already exist are created.
+        :param assignees: Logins the issue should be assigned to, replacing any
+            current ones; a bare string is one login, and an empty sequence
+            unassigns everyone.
+        :param milestone: The number of the milestone to associate the issue
+            with; pass None to detach it.
+        :raises ValueError: If no field is given (the request would be a no-op),
+            if ``state`` is neither open nor closed, if ``state_reason`` is given
+            without ``state``, or if ``state_reason='duplicate'`` and
+            ``duplicate_issue_id`` are not given together.
+        """
+        # GitHub documents state_reason as "ignored unless state is changed", so
+        # sending it alone silently does nothing. Refuse it rather than let the
+        # caller believe an update happened.
+        if isinstance(state, Unset) and not isinstance(state_reason, Unset):
+            raise ValueError(
+                "state_reason is ignored by GitHub unless state changes too; "
+                "pass state (e.g. IssueState.CLOSED) alongside it."
+            )
+        # `duplicate` and `duplicate_issue_id` are only meaningful together:
+        # without the id GitHub rejects the request, and without the reason it
+        # drops the id. Comparison is by value so an equivalent plain string
+        # still takes this path, as it does everywhere else a state is checked.
+        is_duplicate = (
+            not isinstance(state_reason, Unset)
+            and state_reason is not None
+            and str(state_reason) == IssueStateReason.DUPLICATE
+        )
+        if is_duplicate and isinstance(duplicate_issue_id, Unset):
+            raise ValueError(
+                "state_reason='duplicate' requires duplicate_issue_id, the id "
+                "of the issue this one duplicates."
+            )
+        if not is_duplicate and not isinstance(duplicate_issue_id, Unset):
+            raise ValueError(
+                "duplicate_issue_id is ignored by GitHub unless state_reason is "
+                "'duplicate'; pass IssueStateReason.DUPLICATE alongside it."
+            )
+        json: dict[str, Any] = {}
+        if not isinstance(title, Unset):
+            json["title"] = title
+        if not isinstance(body, Unset):
+            json["body"] = body
+        if not isinstance(state, Unset):
+            _validate_issue_state(state)
+            json["state"] = str(state)
+        if not isinstance(state_reason, Unset):
+            json["state_reason"] = None if state_reason is None else str(state_reason)
+        if not isinstance(duplicate_issue_id, Unset):
+            json["duplicate_issue_id"] = duplicate_issue_id
+        if not isinstance(labels, Unset):
+            json["labels"] = list(as_str_sequence(labels))
+        if not isinstance(assignees, Unset):
+            json["assignees"] = list(as_str_sequence(assignees))
+        if not isinstance(milestone, Unset):
+            json["milestone"] = milestone
+        if not json:
+            raise ValueError(
+                f"No field to update was given for issue #{issue_number}; "
+                "pass at least one of title, body, state, state_reason, "
+                "labels, assignees or milestone."
+            )
+        return self._patch(url=f"{self._url_issues}/{issue_number}", json=json).json()
+
+    def close_issue(
+        self,
+        issue_number: int,
+        state_reason: IssueStateReason = IssueStateReason.COMPLETED,
+        duplicate_issue_id: int | Unset = UNSET,
+    ) -> dict[str, Any]:
+        """Close an issue in this repository.
+
+        Closing an already-closed issue is not an error, but it is not a state
+        change either, so GitHub keeps the existing ``state_reason``. Reopen the
+        issue first to re-close it with a different reason.
+
+        :param issue_number: The number of the issue.
+        :param state_reason: Why the issue is being closed (``completed``, the
+            default, ``not_planned`` or ``duplicate``).
+        :param duplicate_issue_id: The id (not the number) of the issue this one
+            duplicates. Required when ``state_reason`` is ``duplicate``, and
+            rejected otherwise (see ``update_issue``).
+        """
+        return self.update_issue(
+            issue_number,
+            state=IssueState.CLOSED,
+            state_reason=state_reason,
+            duplicate_issue_id=duplicate_issue_id,
+        )
+
+    def reopen_issue(self, issue_number: int) -> dict[str, Any]:
+        """Reopen a closed issue in this repository.
+
+        :param issue_number: The number of the issue.
+        """
+        return self.update_issue(
+            issue_number, state=IssueState.OPEN, state_reason=IssueStateReason.REOPENED
+        )
+
+    def update_issue_comment(self, comment_id: int, body: str) -> dict[str, Any]:
+        """Edit an existing comment on an issue or pull request.
+
+        :param comment_id: The id of the comment (its ``id`` field, which is
+            unique repository-wide and unrelated to the issue number).
+        :param body: The new Markdown body, replacing the current one.
+        """
+        return self._patch(
+            url=f"{self._url_issue_comments}/{comment_id}",
+            json={"body": body},
+        ).json()
+
+    def delete_issue_comment(self, comment_id: int) -> requests.Response:
+        """Delete a comment from an issue or pull request.
+
+        :param comment_id: The id of the comment (its ``id`` field, which is
+            unique repository-wide and unrelated to the issue number).
+        """
+        return self._delete(url=f"{self._url_issue_comments}/{comment_id}")
+
+    def get_issue_labels(self, issue_number: int, n: int = 0) -> list[dict[str, Any]]:
+        """List the labels on an issue.
+
+        :param issue_number: The number of the issue.
+        :param n: The maximum number of labels to return (0 means all).
+        """
+        return self._extract_all(url=f"{self._url_issues}/{issue_number}/labels", n=n)
+
+    def add_issue_labels(
+        self, issue_number: int, labels: str | Sequence[str]
+    ) -> list[dict[str, Any]]:
+        """Add labels to an issue, keeping the ones already on it.
+
+        :param issue_number: The number of the issue.
+        :param labels: Names of the labels to add, or a single name as a bare
+            string. Labels that do not already exist are created by GitHub.
+        :return: All labels on the issue after the addition.
+        :raises ValueError: If no label is given. GitHub rejects an empty list
+            here with a 422; use ``set_issue_labels`` to clear labels instead.
+        """
+        names = list(as_str_sequence(labels))
+        if not names:
+            raise ValueError(
+                f"No label to add was given for issue #{issue_number}; "
+                "pass at least one name, or use set_issue_labels(..., ()) to "
+                "remove every label."
+            )
+        return self._post(
+            url=f"{self._url_issues}/{issue_number}/labels",
+            json={"labels": names},
+        ).json()
+
+    def set_issue_labels(
+        self, issue_number: int, labels: str | Sequence[str]
+    ) -> list[dict[str, Any]]:
+        """Replace all labels on an issue with the given ones.
+
+        :param issue_number: The number of the issue.
+        :param labels: Names of the labels the issue should carry, or a single
+            name as a bare string; an empty sequence removes every label.
+        :return: All labels on the issue after the replacement.
+        """
+        return self._put(
+            url=f"{self._url_issues}/{issue_number}/labels",
+            json={"labels": list(as_str_sequence(labels))},
+        ).json()
+
+    def remove_issue_label(self, issue_number: int, label: str) -> list[dict[str, Any]]:
+        """Remove a single label from an issue.
+
+        :param issue_number: The number of the issue.
+        :param label: The name of the label to remove. GitHub responds with 404
+            if the issue does not carry it.
+        :return: The labels remaining on the issue.
+        """
+        # A label name may contain spaces and slashes (e.g. "good first issue"),
+        # so it is URL-encoded rather than interpolated raw into the path.
+        return self._delete(
+            url=f"{self._url_issues}/{issue_number}/labels/{quote(label, safe='')}",
+        ).json()
+
+    def add_issue_assignees(
+        self, issue_number: int, assignees: str | Sequence[str]
+    ) -> dict[str, Any]:
+        """Assign users to an issue, keeping those already assigned.
+
+        :param issue_number: The number of the issue.
+        :param assignees: Logins to assign, or a single login as a bare string.
+            A login without push access to the repository is silently ignored.
+        :return: The updated issue.
+        """
+        return self._post(
+            url=f"{self._url_issues}/{issue_number}/assignees",
+            json={"assignees": list(as_str_sequence(assignees))},
+        ).json()
+
+    def remove_issue_assignees(
+        self, issue_number: int, assignees: str | Sequence[str]
+    ) -> dict[str, Any]:
+        """Unassign users from an issue, leaving the other assignees in place.
+
+        :param issue_number: The number of the issue.
+        :param assignees: Logins to unassign, or a single login as a bare string.
+        :return: The updated issue.
+        """
+        return self._delete(
+            url=f"{self._url_issues}/{issue_number}/assignees",
+            json={"assignees": list(as_str_sequence(assignees))},
+        ).json()
+
+    def get_milestones(
+        self, state: IssueState = IssueState.OPEN, n: int = 0
+    ) -> list[dict[str, Any]]:
+        """List milestones in this repository.
+
+        :param state: Filter milestones by state: ``open`` (the default),
+            ``closed``, or ``all``.
+        :param n: The maximum number of milestones to return (0 means all).
+        """
+        return self._extract_all(url=self._url_milestones, params={"state": state}, n=n)
+
+    def create_milestone(
+        self,
+        title: str,
+        description: str = "",
+        due_on: str = "",
+    ) -> dict[str, Any]:
+        """Create a milestone in this repository.
+
+        :param title: The title of the milestone.
+        :param description: A description of the milestone.
+        :param due_on: When the milestone is due, as an ISO-8601 timestamp
+            (e.g. ``2026-12-31T00:00:00Z``).
+        :return: The new milestone, whose ``number`` is what ``create_issue``
+            and ``update_issue`` take as their ``milestone``.
+        """
+        json: dict[str, Any] = {"title": title}
+        if description:
+            json["description"] = description
+        if due_on:
+            json["due_on"] = due_on
+        return self._post(url=self._url_milestones, json=json).json()
+
+    def update_milestone(
+        self,
+        milestone_number: int,
+        *,
+        title: str | Unset = UNSET,
+        description: str | Unset = UNSET,
+        state: IssueState | Unset = UNSET,
+        due_on: str | Unset = UNSET,
+    ) -> dict[str, Any]:
+        """Update a milestone in this repository.
+
+        As in ``update_issue``, only the fields passed are sent.
+
+        :param milestone_number: The ``number`` of the milestone (not its id).
+        :param title: A new title.
+        :param description: A new description; pass ``""`` to empty it.
+        :param state: ``open`` or ``closed``.
+        :param due_on: A new due date, as an ISO-8601 timestamp. GitHub's
+            milestone endpoint takes no null due date, so an existing one can be
+            moved but not removed.
+        :raises ValueError: If no field is given, if ``state`` is neither open
+            nor closed, or if ``due_on`` is empty.
+        """
+        json: dict[str, Any] = {}
+        if not isinstance(title, Unset):
+            json["title"] = title
+        if not isinstance(description, Unset):
+            json["description"] = description
+        if not isinstance(state, Unset):
+            _validate_issue_state(state, noun="milestone")
+            json["state"] = str(state)
+        if not isinstance(due_on, Unset):
+            if not due_on:
+                raise ValueError(
+                    "due_on must be a non-empty ISO-8601 timestamp; GitHub "
+                    "rejects an empty one and offers no way to clear a due date."
+                )
+            json["due_on"] = due_on
+        if not json:
+            raise ValueError(
+                f"No field to update was given for milestone #{milestone_number}; "
+                "pass at least one of title, description, state or due_on."
+            )
+        return self._patch(
+            url=f"{self._url_milestones}/{milestone_number}", json=json
+        ).json()
+
+    def delete_milestone(self, milestone_number: int) -> requests.Response:
+        """Delete a milestone from this repository.
+
+        Issues associated with the milestone are not deleted; they simply lose it.
+
+        :param milestone_number: The ``number`` of the milestone (not its id).
+        """
+        return self._delete(url=f"{self._url_milestones}/{milestone_number}")
 
     def get_issue_comments(self, issue_number: int, n: int = 0) -> list[dict[str, Any]]:
         """List comments on an issue in this repository.

--- a/github_rest_api/scripts/github/auto_merge_pull_request.py
+++ b/github_rest_api/scripts/github/auto_merge_pull_request.py
@@ -70,8 +70,9 @@ def parse_args(args=None, namespace=None) -> Namespace:
     parser.add_argument(
         "--merge-method",
         dest="merge_method",
-        choices=[m.value for m in MergeMethod],
-        default=MergeMethod.MERGE.value,
+        type=MergeMethod,
+        choices=list(MergeMethod),
+        default=MergeMethod.MERGE,
         help="The merge method to use.",
     )
     parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,4 +48,5 @@ dev = [
 
 [tool.ruff]
 # select the 'I' rule set for import sorting
-lint.extend-select = [ "I" ]
+# and 'RUF022' to keep the elements of `__all__` sorted
+lint.extend-select = [ "I", "RUF022" ]

--- a/tests/test_auto_merge_pull_request.py
+++ b/tests/test_auto_merge_pull_request.py
@@ -1,0 +1,16 @@
+from github_rest_api.github import MergeMethod
+from github_rest_api.scripts.github import auto_merge_pull_request
+
+
+def test_parse_args_merge_method_is_an_enum_member():
+    """`--merge-method` is converted, so the namespace holds a MergeMethod.
+
+    `is` rather than `==`: a plain string compares equal to a StrEnum member,
+    so `==` would still pass if the conversion were dropped.
+    """
+    args = auto_merge_pull_request.parse_args(["--token", "t"])
+    assert args.merge_method is MergeMethod.MERGE
+    args = auto_merge_pull_request.parse_args(
+        ["--token", "t", "--merge-method", "squash"]
+    )
+    assert args.merge_method is MergeMethod.SQUASH

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -2,6 +2,7 @@ import os
 from base64 import b64decode
 from contextlib import ExitStack
 from datetime import datetime, timedelta, timezone
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +11,8 @@ from nacl import encoding, public
 
 from github_rest_api.github import (
     DEFAULT_TIMEOUT,
+    IssueState,
+    IssueStateReason,
     MergeMethod,
     Organization,
     Repository,
@@ -210,6 +213,472 @@ def test_create_issue_comment_reaches_requests_post():
         "https://api.github.com/repos/owner/name/issues/7/comments"
     )
     assert mock_post.call_args.kwargs["json"] == {"body": "a comment"}
+
+
+def test_create_issue_passes_milestone():
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_post", return_value=MagicMock()) as mock_post:
+        repo.create_issue("a title", milestone=3)
+    assert mock_post.call_args.kwargs["json"] == {"title": "a title", "milestone": 3}
+
+
+def test_get_issue_passes_url():
+    repo = Repository("token", "owner/name")
+    response = MagicMock()
+    response.json.return_value = {"number": 7}
+    with patch.object(repo, "_get", return_value=response) as mock_get:
+        assert repo.get_issue(7) == {"number": 7}
+    assert mock_get.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/issues/7"
+    )
+
+
+def _mock_helper(repo, method, payload=None):
+    """Patch an HTTP helper of `repo` so its response decodes to `payload`."""
+    response = MagicMock()
+    response.json.return_value = payload
+    return patch.object(repo, method, return_value=response)
+
+
+def test_update_issue_sends_only_given_fields_and_returns_json():
+    """An unmentioned field is left out entirely, never nulled or re-sent."""
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch", {"number": 7}) as mock_patch:
+        assert repo.update_issue(7, title="new title") == {"number": 7}
+    assert mock_patch.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/issues/7"
+    )
+    assert mock_patch.call_args.kwargs["json"] == {"title": "new title"}
+
+
+def test_update_issue_sends_empty_body():
+    """`body=""` empties the body; it must not be dropped as falsy."""
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.update_issue(7, body="")
+    assert mock_patch.call_args.kwargs["json"] == {"body": ""}
+
+
+def test_update_issue_clears_milestone_with_none():
+    """`milestone=None` detaches the milestone, distinct from omitting it."""
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.update_issue(7, milestone=None)
+    assert mock_patch.call_args.kwargs["json"] == {"milestone": None}
+
+
+def test_update_issue_clears_labels_and_assignees_with_empty_sequence():
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.update_issue(7, labels=(), assignees=())
+    assert mock_patch.call_args.kwargs["json"] == {"labels": [], "assignees": []}
+
+
+def test_update_issue_accepts_bare_string_labels_and_assignees():
+    """A bare string is one label/assignee, not one per character."""
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.update_issue(7, labels="bug", assignees="dclong")
+    assert mock_patch.call_args.kwargs["json"] == {
+        "labels": ["bug"],
+        "assignees": ["dclong"],
+    }
+
+
+def test_update_issue_serializes_enum_values():
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.update_issue(
+            7, state=IssueState.CLOSED, state_reason=IssueStateReason.NOT_PLANNED
+        )
+    assert mock_patch.call_args.kwargs["json"] == {
+        "state": "closed",
+        "state_reason": "not_planned",
+    }
+
+
+def test_update_issue_sends_null_state_reason():
+    """`state_reason=None` reaches GitHub as JSON null, not as an omitted key."""
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.update_issue(7, state=IssueState.OPEN, state_reason=None)
+    assert mock_patch.call_args.kwargs["json"] == {
+        "state": "open",
+        "state_reason": None,
+    }
+
+
+@pytest.mark.parametrize("state_reason", [None, IssueStateReason.NOT_PLANNED])
+def test_update_issue_rejects_state_reason_without_state(state_reason):
+    """GitHub ignores `state_reason` unless `state` changes, so it is refused.
+
+    Sending it alone would look like an update but silently do nothing.
+    """
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_patch") as mock_patch:
+        with pytest.raises(ValueError, match="state_reason is ignored"):
+            repo.update_issue(7, state_reason=state_reason)
+    mock_patch.assert_not_called()
+
+
+def test_update_issue_passes_duplicate_issue_id():
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.update_issue(
+            7,
+            state=IssueState.CLOSED,
+            state_reason=IssueStateReason.DUPLICATE,
+            duplicate_issue_id=98765,
+        )
+    assert mock_patch.call_args.kwargs["json"] == {
+        "state": "closed",
+        "state_reason": "duplicate",
+        "duplicate_issue_id": 98765,
+    }
+
+
+def test_update_issue_accepts_duplicate_as_bare_string():
+    """The pairing check compares by value, so a plain string works too.
+
+    The signature names the enums, but a state read from JSON or a command line
+    arrives as a plain string; the checks stay value-based so it still works.
+    Hence the deliberately untyped arguments below.
+    """
+    repo = Repository("token", "owner/name")
+    # Passed as untyped keywords, the way such a value reaches the call in
+    # practice; spelling them out inline would just be a type error.
+    untyped: dict[str, Any] = {"state": "closed", "state_reason": "duplicate"}
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.update_issue(7, duplicate_issue_id=98765, **untyped)
+    assert mock_patch.call_args.kwargs["json"] == {
+        "state": "closed",
+        "state_reason": "duplicate",
+        "duplicate_issue_id": 98765,
+    }
+
+
+def test_update_issue_omits_duplicate_issue_id_by_default():
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.update_issue(7, title="t")
+    assert "duplicate_issue_id" not in mock_patch.call_args.kwargs["json"]
+
+
+def test_update_issue_requires_duplicate_issue_id_for_duplicate():
+    """GitHub 422s on `duplicate` without the id, so it is caught early."""
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_patch") as mock_patch:
+        with pytest.raises(ValueError, match="requires duplicate_issue_id"):
+            repo.update_issue(
+                7, state=IssueState.CLOSED, state_reason=IssueStateReason.DUPLICATE
+            )
+    mock_patch.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"title": "t"},
+        {"state": IssueState.CLOSED, "state_reason": IssueStateReason.NOT_PLANNED},
+        {"state": IssueState.OPEN, "state_reason": None},
+    ],
+)
+def test_update_issue_rejects_duplicate_issue_id_without_duplicate(kwargs):
+    """GitHub drops the id unless the reason is `duplicate`, so it is refused.
+
+    Sending it regardless would look like it took effect when it did not.
+    """
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_patch") as mock_patch:
+        with pytest.raises(ValueError, match="duplicate_issue_id is ignored"):
+            repo.update_issue(7, duplicate_issue_id=98765, **kwargs)
+    mock_patch.assert_not_called()
+
+
+def test_close_issue_as_duplicate_without_id_raises():
+    """`close_issue` inherits the pairing checks from `update_issue`."""
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_patch") as mock_patch:
+        with pytest.raises(ValueError, match="requires duplicate_issue_id"):
+            repo.close_issue(7, IssueStateReason.DUPLICATE)
+    mock_patch.assert_not_called()
+
+
+def test_update_issue_without_fields_raises():
+    """A field-less update would be a wasted request, so it is refused."""
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_patch") as mock_patch:
+        with pytest.raises(ValueError, match="No field to update"):
+            repo.update_issue(7)
+    mock_patch.assert_not_called()
+
+
+@pytest.mark.parametrize("state", [IssueState.ALL, "reopened", ""])
+def test_update_issue_rejects_invalid_state(state):
+    """`all` is a listing filter, not a state an issue can be set to."""
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_patch") as mock_patch:
+        with pytest.raises(ValueError, match="Invalid issue state"):
+            repo.update_issue(7, state=state)
+    mock_patch.assert_not_called()
+
+
+def test_close_issue_defaults_to_completed():
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.close_issue(7)
+    assert mock_patch.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/issues/7"
+    )
+    assert mock_patch.call_args.kwargs["json"] == {
+        "state": "closed",
+        "state_reason": "completed",
+    }
+
+
+def test_close_issue_passes_state_reason():
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.close_issue(7, IssueStateReason.NOT_PLANNED)
+    assert mock_patch.call_args.kwargs["json"] == {
+        "state": "closed",
+        "state_reason": "not_planned",
+    }
+
+
+def test_close_issue_as_duplicate_passes_duplicate_issue_id():
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.close_issue(7, IssueStateReason.DUPLICATE, duplicate_issue_id=98765)
+    assert mock_patch.call_args.kwargs["json"] == {
+        "state": "closed",
+        "state_reason": "duplicate",
+        "duplicate_issue_id": 98765,
+    }
+
+
+def test_reopen_issue_payload():
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.reopen_issue(7)
+    assert mock_patch.call_args.kwargs["json"] == {
+        "state": "open",
+        "state_reason": "reopened",
+    }
+
+
+def test_update_issue_comment_targets_comment_id():
+    """Comments are edited by comment id, not by the issue number."""
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.update_issue_comment(4321, "edited")
+    assert mock_patch.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/issues/comments/4321"
+    )
+    assert mock_patch.call_args.kwargs["json"] == {"body": "edited"}
+
+
+def test_delete_issue_comment_targets_comment_id():
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_delete", return_value=MagicMock()) as mock_delete:
+        repo.delete_issue_comment(4321)
+    assert mock_delete.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/issues/comments/4321"
+    )
+
+
+def test_get_issue_labels_passes_url_and_limit():
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_extract_all", return_value=[]) as mock_extract:
+        repo.get_issue_labels(7, n=5)
+    assert mock_extract.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/issues/7/labels"
+    )
+    assert mock_extract.call_args.kwargs["n"] == 5
+
+
+def test_add_issue_labels_posts_to_issue_labels():
+    repo = Repository("token", "owner/name")
+    labels = [{"name": "bug"}, {"name": "wontfix"}]
+    with _mock_helper(repo, "_post", labels) as mock_post:
+        assert repo.add_issue_labels(7, ("bug", "wontfix")) == labels
+    assert mock_post.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/issues/7/labels"
+    )
+    assert mock_post.call_args.kwargs["json"] == {"labels": ["bug", "wontfix"]}
+
+
+@pytest.mark.parametrize("labels", [(), "", []])
+def test_add_issue_labels_rejects_empty(labels):
+    """GitHub 422s on an empty `labels` array, so it is caught before the request.
+
+    A bare `""` (an unset env var or config field) reaches here as an empty
+    sequence, which is the case most likely to hit this in practice.
+    """
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_post") as mock_post:
+        with pytest.raises(ValueError, match="No label to add"):
+            repo.add_issue_labels(7, labels)
+    mock_post.assert_not_called()
+
+
+def test_set_issue_labels_puts_to_issue_labels():
+    """PUT replaces the label set, so an empty list clears every label."""
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_put") as mock_put:
+        repo.set_issue_labels(7, ())
+    assert mock_put.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/issues/7/labels"
+    )
+    assert mock_put.call_args.kwargs["json"] == {"labels": []}
+
+
+@pytest.mark.parametrize(
+    ("labels", "method", "helper"),
+    [
+        ("bug", "add_issue_labels", "_post"),
+        ("bug", "set_issue_labels", "_put"),
+    ],
+)
+def test_issue_labels_accept_bare_string(labels, method, helper):
+    """A bare string is one label, not one per character."""
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, helper) as mock_request:
+        getattr(repo, method)(7, labels)
+    assert mock_request.call_args.kwargs["json"] == {"labels": ["bug"]}
+
+
+def test_remove_issue_label_url_encodes_name_and_returns_remaining():
+    """A label name may contain spaces or slashes, so it is encoded."""
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_delete", [{"name": "bug"}]) as mock_delete:
+        assert repo.remove_issue_label(7, "good first issue") == [{"name": "bug"}]
+    assert mock_delete.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/issues/7/labels/good%20first%20issue"
+    )
+
+
+def test_add_issue_assignees_posts_to_assignees():
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_post") as mock_post:
+        repo.add_issue_assignees(7, "dclong")
+    assert mock_post.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/issues/7/assignees"
+    )
+    assert mock_post.call_args.kwargs["json"] == {"assignees": ["dclong"]}
+
+
+def test_remove_issue_assignees_deletes_with_body():
+    """The unassign endpoint takes the logins in the DELETE body."""
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_delete", {"number": 7}) as mock_delete:
+        assert repo.remove_issue_assignees(7, ("dclong", "other")) == {"number": 7}
+    assert mock_delete.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/issues/7/assignees"
+    )
+    assert mock_delete.call_args.kwargs["json"] == {"assignees": ["dclong", "other"]}
+
+
+def test_get_milestones_passes_url_state_and_limit():
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_extract_all", return_value=[]) as mock_extract:
+        repo.get_milestones(n=5)
+    assert mock_extract.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/milestones"
+    )
+    assert mock_extract.call_args.kwargs["params"] == {"state": "open"}
+    assert mock_extract.call_args.kwargs["n"] == 5
+
+
+def test_create_milestone_omits_empty_optional_fields():
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_post") as mock_post:
+        repo.create_milestone("v1.0")
+    assert mock_post.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/milestones"
+    )
+    assert mock_post.call_args.kwargs["json"] == {"title": "v1.0"}
+
+
+def test_create_milestone_passes_optional_fields():
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_post") as mock_post:
+        repo.create_milestone(
+            "v1.0", description="first", due_on="2026-12-31T00:00:00Z"
+        )
+    assert mock_post.call_args.kwargs["json"] == {
+        "title": "v1.0",
+        "description": "first",
+        "due_on": "2026-12-31T00:00:00Z",
+    }
+
+
+def test_update_milestone_sends_only_given_fields():
+    repo = Repository("token", "owner/name")
+    with _mock_helper(repo, "_patch") as mock_patch:
+        repo.update_milestone(3, state=IssueState.CLOSED)
+    assert mock_patch.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/milestones/3"
+    )
+    assert mock_patch.call_args.kwargs["json"] == {"state": "closed"}
+
+
+def test_update_milestone_without_fields_raises():
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_patch") as mock_patch:
+        with pytest.raises(ValueError, match="No field to update"):
+            repo.update_milestone(3)
+    mock_patch.assert_not_called()
+
+
+def test_update_milestone_rejects_invalid_state():
+    """The error names the milestone, and renders the enum as its plain value."""
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_patch") as mock_patch:
+        with pytest.raises(ValueError, match="Invalid milestone state 'all'"):
+            repo.update_milestone(3, state=IssueState.ALL)
+    mock_patch.assert_not_called()
+
+
+def test_update_milestone_rejects_empty_due_on():
+    """GitHub takes no null due date, so an empty one is a 422 caught early."""
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_patch") as mock_patch:
+        with pytest.raises(ValueError, match="due_on must be"):
+            repo.update_milestone(3, due_on="")
+    mock_patch.assert_not_called()
+
+
+def test_delete_milestone_passes_url():
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_delete", return_value=MagicMock()) as mock_delete:
+        repo.delete_milestone(3)
+    assert mock_delete.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/milestones/3"
+    )
+
+
+def test_get_pull_request_review_comments_passes_url_and_limit():
+    """The line-anchored comments live under /pulls/{n}/comments, not /issues."""
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "_extract_all", return_value=[]) as mock_extract:
+        repo.get_pull_request_review_comments(7, n=5)
+    assert mock_extract.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/pulls/7/comments"
+    )
+    assert mock_extract.call_args.kwargs["n"] == 5
+
+
+def test_get_pull_request_review_comments_paginates():
+    """All pages are collected, so a long review is not truncated at 100."""
+    repo = Repository("token", "owner/name")
+    full_page, last_page = MagicMock(), MagicMock()
+    full_page.json.return_value = [{"id": i} for i in range(100)]
+    last_page.json.return_value = [{"id": 100}]
+    with patch.object(repo, "_get", side_effect=[full_page, last_page]) as mock_get:
+        comments = repo.get_pull_request_review_comments(7)
+    assert len(comments) == 101
+    assert mock_get.call_count == 2
 
 
 def test_compare_url_encodes_branch_names():


### PR DESCRIPTION
## Summary

- feat: add IssueStateReason enum and milestone support for issues

## Changed files

**Added**
- `tests/test_auto_merge_pull_request.py` (+16/-0)
**Modified**
- `github_rest_api/__init__.py` (+6/-0)
- `github_rest_api/github.py` (+446/-17)
- `github_rest_api/scripts/github/auto_merge_pull_request.py` (+3/-2)
- `pyproject.toml` (+2/-1)
- `tests/test_github.py` (+469/-0)

## Commits

- cc4620e feat: add IssueStateReason enum and milestone support for issues