### PR TITLE
feat: add create_issue_comment_image method for posting images in issue comments

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,8 +11,12 @@ jobs:
         os: 
           - macOS-latest
           - ubuntu-latest
-        python-version: 
-          - "3.12"
+        # The oldest supported patch release, spelled out rather than "3.12":
+        # a bare "3.12" resolves to the runner's system interpreter, which is
+        # below `requires-python` on ubuntu-latest, and uv then fails outright
+        # instead of looking for a compatible interpreter to download.
+        python-version:
+          - "3.12.7"
           - "3.13"
           - "3.14"
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ A simple Python wrapper for GitHub REST APIs, optimized for use in GitHub Action
 - **Purpose:** Provide a streamlined interface for interacting with GitHub's REST API
   and performing Git operations within automation scripts.
 - **Main Technologies:**
-  - **Python 3.12+**: Core language.
+  - **Python 3.12.7+**: Core language.
   - **requests**: For HTTP interactions with the GitHub API.
   - **dulwich**: A pure-Python implementation of Git for repository operations.
   - **tenacity**: For retry logic on API requests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/github_rest_api/github.py
+++ b/github_rest_api/github.py
@@ -1465,6 +1465,32 @@ class Repository(GitHub):
             json={"body": body},
         ).json()
 
+    def create_issue_comment_image(
+        self, issue_number: int, url: str, alt: str = "", body: str = ""
+    ) -> dict[str, Any]:
+        """Add a comment containing an image to an issue.
+
+        GitHub has no public API for the attachment upload that its web UI
+        performs on drag and drop, so the image must already be hosted
+        somewhere reachable; this method only references it.
+
+        :param issue_number: The number of the issue.
+        :param url: The URL of an already uploaded image.
+        :param alt: Alt text of the image.
+        :param body: Optional text placed above the image.
+        """
+        # A bracket in the alt text would close the markdown label early and
+        # degrade the whole image to literal text, so escape both brackets
+        # (and the escape character itself, which must come first).
+        alt = alt.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
+        # The URL is wrapped in angle brackets so that spaces and unbalanced
+        # parentheses, which are common in URLs derived from file names, do
+        # not terminate the markdown link early.
+        image = f"![{alt}](<{url}>)"
+        return self.create_issue_comment(
+            issue_number, f"{body}\n\n{image}" if body else image
+        )
+
     def archive(self) -> requests.Response:
         return self._patch(
             url=self._url_repo,

--- a/github_rest_api/scripts/github/create_github_repo.py
+++ b/github_rest_api/scripts/github/create_github_repo.py
@@ -1,9 +1,7 @@
 """Add a GitHub repository and initialize a local Git repository with workflows."""
 
 import argparse
-import getpass
 import logging
-import os
 import shutil
 import sys
 from collections.abc import Sequence
@@ -13,15 +11,10 @@ from dulwich import porcelain
 from dulwich.refs import HEADREF, LOCAL_BRANCH_PREFIX, Ref
 
 from github_rest_api import Organization, User
+from github_rest_api.scripts.utils import resolve_github_token, validate_repo
 from github_rest_api.utils import as_str_sequence
 
 logger = logging.getLogger(__name__)
-
-
-def _validate_repo(repo: str) -> None:
-    parts = repo.split("/")
-    if len(parts) != 2 or not parts[0] or not parts[1]:
-        raise ValueError(f"Invalid repo format '{repo}'. Expected 'owner/repo'.")
 
 
 def _create_remote_repo(
@@ -169,15 +162,9 @@ def create_github_repo(
     branches: Sequence[str] = ("main",),
 ) -> None:
     branches = as_str_sequence(branches)
-    token = token or os.getenv("GITHUB_TOKEN", "")
-    if not token:
-        token = getpass.getpass("Please enter your GitHub token: ")
-        if not token:
-            raise ValueError(
-                "No GitHub token is provided (via $GITHUB_TOKEN, --token or at prompt)."
-            )
+    token = resolve_github_token(token)
     repo = repo.strip()
-    _validate_repo(repo)
+    validate_repo(repo)
     _create_remote_repo(
         repo=repo, private=private, token=token, is_owner_user=is_owner_user
     )

--- a/github_rest_api/scripts/github/release_on_github.py
+++ b/github_rest_api/scripts/github/release_on_github.py
@@ -1,18 +1,20 @@
-import argparse
 import re
 import sys
 from pathlib import Path
 
 from github_rest_api import Repository
 from github_rest_api.scripts.utils import (
+    RedactingArgumentParser,
     find_project_root,
     get_project_version,
     get_repo,
+    reject_github_token,
     resolve_github_token,
 )
 
 
 def _get_release_tag(tag: str, root: Path, validate: bool = True) -> str:
+    reject_github_token("--tag", tag)
     tag = tag.strip()
     if not tag:
         tag = get_project_version(root).strip()
@@ -53,7 +55,14 @@ def release_on_github(
     :param token: GitHub token.
         If not specified, the GITHUB_TOKEN environment variable is used.
     :param validate: If True, validate the tag against semantic versioning format before creating the release.
+    :raises ValueError: If a value that looks like a GitHub token is specified
+        for anything other than the token itself.
     """
+    # A release is public, so a token mistyped into any of these would be
+    # published. -t is the tag on this script rather than the token, which
+    # makes that slip easy; --no-validate would otherwise let it through.
+    reject_github_token("--branch", branch)
+    reject_github_token("--notes", notes)
     root = find_project_root()
     if not root:
         raise FileNotFoundError("Could not find project root (no .git found).")
@@ -80,7 +89,7 @@ def release_on_github(
 
 
 def parse_args(args=None, namespace=None):
-    parser = argparse.ArgumentParser(
+    parser = RedactingArgumentParser(
         description="Make a release of the project on GitHub."
     )
     parser.add_argument(
@@ -90,7 +99,9 @@ def parse_args(args=None, namespace=None):
         help="The branch (default to main) from which to make the release.",
     )
     parser.add_argument(
-        "-t",
+        # No short option on purpose: -t reads as the token to anyone used to
+        # the other scripts, and the tag becomes the public name of the
+        # release, so that slip would publish the token.
         "--tag",
         default="",
         help="The tag for the release. If not specified, the version from project configuration is used.",

--- a/github_rest_api/scripts/github/release_on_github.py
+++ b/github_rest_api/scripts/github/release_on_github.py
@@ -1,6 +1,4 @@
 import argparse
-import getpass
-import os
 import re
 import sys
 from pathlib import Path
@@ -10,6 +8,7 @@ from github_rest_api.scripts.utils import (
     find_project_root,
     get_project_version,
     get_repo,
+    resolve_github_token,
 )
 
 
@@ -65,13 +64,7 @@ def release_on_github(
     if not repo_name:
         raise ValueError("Could not find GitHub repository name.")
 
-    token = token or os.getenv("GITHUB_TOKEN", "")
-    if not token:
-        token = getpass.getpass("Please enter your GitHub token: ")
-        if not token:
-            raise ValueError(
-                "No GitHub token is provided (via $GITHUB_TOKEN, --token or at prompt)."
-            )
+    token = resolve_github_token(token)
     repo = Repository(token=token, repo=repo_name)
     data = {
         "tag_name": tag,

--- a/github_rest_api/scripts/github/upload_image_to_issue.py
+++ b/github_rest_api/scripts/github/upload_image_to_issue.py
@@ -1,0 +1,541 @@
+"""Upload an image and post it as a new comment on a GitHub issue.
+
+GitHub has no public API for the attachment upload that its web UI performs on
+drag and drop, so an image has to be hosted elsewhere before it can be
+referenced from a comment. This script hosts it on Cloudinary through the
+Cloudinary CLI (``cld``), which is expected to be authenticated through its own
+environment variables.
+"""
+
+import json
+import re
+import shutil
+import subprocess as sp
+import sys
+from argparse import ArgumentParser, Namespace
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import Any, NoReturn
+
+from github_rest_api import IssueState, Repository
+from github_rest_api.scripts.utils import resolve_github_token, validate_repo
+from github_rest_api.utils import as_str_sequence
+
+POPULAR_REPOS = ("dclong/tasks", "legendu-net/blog")
+# fzf reports both "nothing matched the query" and "the user walked away" through
+# its exit code, and neither is a failure of the command itself.
+FZF_EXIT_NO_MATCH = 1
+FZF_EXIT_ERROR = 2
+FZF_EXIT_ABORT = 130
+# The prefixed GitHub token formats: gh[pousr]_ for the classic ones and
+# github_pat_ for fine-grained ones. The trailing lengths are open ended
+# because GitHub reserves the right to grow tokens up to 255 characters, and
+# the prefix plus 20+ alphanumerics is already specific enough that ordinary
+# prose cannot trip it.
+GITHUB_TOKEN = re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{22,}")
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+SECURE_URL = re.compile(r'"secure_url"\s*:\s*"(?P<url>[^"]+)"')
+CLOUDINARY_URL = re.compile(r"https://res\.cloudinary\.com/\S+")
+TAGS_HELP = (
+    "Tags to attach to the uploaded image. Both comma- and space-delimited "
+    "values are accepted and can be mixed, so that --tags holiday,summer and "
+    "--tags holiday summer are equivalent, as is --tags 'holiday, summer'. "
+    "A tag containing spaces has to be quoted, so that --tags 'my son' beach "
+    "attaches the 2 tags 'my son' and 'beach'; a tag cannot contain a comma, "
+    "which always separates tags. Surrounding whitespace is trimmed, empty "
+    "entries are dropped and duplicates removed (the first occurrence decides "
+    "the order). Ignored together with --image-url, since nothing is uploaded "
+    "in that case."
+)
+
+
+def parse_tags(tags: str | Sequence[str]) -> list[str]:
+    """Split tags on commas into a normalized list.
+
+    Space-delimited tags need no handling here because the shell has already
+    split them into separate values. Splitting on whitespace as well would make
+    a tag containing a space (``my son``) impossible to express, so quoting a
+    value is what marks it as a single tag.
+
+    :param tags: Tags as a bare string or as a sequence of strings, each of
+        which may itself hold several comma-delimited tags.
+    """
+    result: list[str] = []
+    for tag in as_str_sequence(tags):
+        for part in tag.split(","):
+            part = part.strip()
+            if part and part not in result:
+                result.append(part)
+    return result
+
+
+class RedactingArgumentParser(ArgumentParser):
+    """An ``ArgumentParser`` that keeps GitHub tokens out of its own errors.
+
+    argparse quotes the offending value back at the user for an unrecognized
+    option or a bad type, so ``-t <token>`` -- the very slip that dropping the
+    short ``-t`` is meant to catch -- would print the token to stderr.
+    """
+
+    def error(self, message: str) -> NoReturn:
+        super().error(GITHUB_TOKEN.sub("<redacted>", message))
+
+
+def reject_github_token(option: str, value: str) -> None:
+    """Refuse a value that looks like a GitHub token.
+
+    Only ``--token`` is meant to carry one. Everything else this script accepts
+    ends up somewhere public: an issue title, a comment body, an image tag. A
+    token mistyped into one of those is disclosed to everyone who can read the
+    repository, so it is rejected rather than sent.
+
+    The offending value is deliberately kept out of the error message, which
+    would otherwise copy the token into logs and terminal scrollback.
+
+    :param option: The name of the option the value came from, for the message.
+    :param value: The value to check.
+    :raises ValueError: If the value contains something shaped like a token.
+    """
+    if GITHUB_TOKEN.search(value):
+        raise ValueError(
+            f"The value passed to {option} looks like a GitHub token. Pass a "
+            "token with --token or $GITHUB_TOKEN instead. If it is a real "
+            "token, revoke it: it is already in your shell history."
+        )
+
+
+def cloudinary_folder(repo: str) -> str:
+    """Derive the Cloudinary folder to upload to from a GitHub repository.
+
+    :param repo: A GitHub repository of the form ``owner/repo``, whose name
+        (``repo``) is used as the folder.
+    """
+    return repo.split("/")[-1]
+
+
+def issue_choices(issues: Iterable[dict[str, Any]]) -> list[str]:
+    """Build the ``<number>\\t<title>`` lines to feed to the issue picker.
+
+    GitHub's issues endpoint also returns pull requests, which are dropped here.
+    Whitespace is squeezed out of every title so that an issue is always exactly
+    one record holding exactly one delimiter.
+
+    :param issues: Issues as returned by ``Repository.get_issues``.
+    """
+    return [
+        f"{issue['number']}\t{' '.join(str(issue.get('title', '')).split())}"
+        for issue in issues
+        if "pull_request" not in issue
+    ]
+
+
+def _run_fzf(candidates: Sequence[str], *options: str) -> sp.CompletedProcess[str]:
+    """Run fzf over the given candidates and return the completed process.
+
+    ``check=True`` is deliberately not used: fzf reports "nothing matched" and
+    "the user aborted" through its exit code, and the callers interpret both
+    rather than treating them as errors.
+
+    :param candidates: The lines to choose from.
+    :param options: Additional command line options for fzf.
+    """
+    if not shutil.which("fzf"):
+        raise FileNotFoundError(
+            "fzf is not installed but is needed to select a repository or an "
+            "issue interactively. Install fzf, or pass --repo, --issue-number "
+            "or --issue-title explicitly."
+        )
+    # --no-multi is passed explicitly because $FZF_DEFAULT_OPTS is merged into
+    # every invocation, and a --multi in there would spread a selection over
+    # several lines and silently break the parsing below.
+    proc = sp.run(
+        ["fzf", "--no-multi", "--height=40%", "--reverse", *options],
+        input="\n".join(candidates),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode == FZF_EXIT_ERROR:
+        raise RuntimeError(
+            f"fzf failed: {proc.stderr.strip() or 'unknown error'}. An "
+            "interactive terminal is required to select interactively."
+        )
+    return proc
+
+
+def parse_fzf_repo(returncode: int, stdout: str) -> str:
+    """Interpret the output of the repository picker.
+
+    Given ``--print-query``, fzf prints the typed query as the first line and,
+    when an entry was actually selected, that entry as the second one. An exit
+    code of 0 therefore means a listed repository was picked, 1 means the query
+    matched nothing and is itself the repository to use, and 130 means the
+    picker was cancelled, in which case fzf prints nothing at all.
+
+    :param returncode: The exit code of fzf.
+    :param stdout: The standard output of fzf.
+    """
+    if returncode == FZF_EXIT_ABORT:
+        raise ValueError("No repository was selected (the picker was cancelled).")
+    lines = stdout.splitlines()
+    query = lines[0].strip() if lines else ""
+    selection = lines[1].strip() if len(lines) > 1 else ""
+    if repo := selection or query:
+        return repo
+    raise ValueError("No repository was selected or entered.")
+
+
+def parse_fzf_issue(returncode: int, stdout: str) -> int:
+    """Interpret the output of the issue picker.
+
+    :param returncode: The exit code of fzf.
+    :param stdout: The standard output of fzf, a single ``<number>\\t<title>``
+        line since the issue picker does not use ``--print-query``.
+    """
+    if returncode == FZF_EXIT_ABORT:
+        raise ValueError("No issue was selected (the picker was cancelled).")
+    line = stdout.strip()
+    if not line:
+        raise ValueError("No issue was selected.")
+    number = line.split("\t", 1)[0].strip()
+    if not number.isdigit():
+        raise ValueError(f"Could not parse an issue number out of '{line}'.")
+    return int(number)
+
+
+def select_repo() -> str:
+    """Select a GitHub repository interactively.
+
+    Any repository can be typed in freely; the popular ones are merely offered.
+    Matching is exact rather than fuzzy so that a typed repository is not
+    hijacked by a loose match against one of the offered ones.
+    """
+    proc = _run_fzf(
+        POPULAR_REPOS,
+        "--print-query",
+        "--exact",
+        "--prompt=repo> ",
+        "--header=Select a repository, or type any owner/repo and press Enter.",
+    )
+    return parse_fzf_repo(proc.returncode, proc.stdout)
+
+
+def select_issue(repository: Repository) -> int:
+    """Select an open issue of the repository interactively.
+
+    :param repository: The repository whose open issues to choose from.
+    """
+    choices = issue_choices(repository.get_issues(state=IssueState.OPEN))
+    if not choices:
+        # Without this, the user would land in an empty picker that can only be
+        # escaped with Esc, which then reports a cancellation instead of the
+        # real reason.
+        raise ValueError(
+            "There is no open issue to select. Use --issue-title to create one."
+        )
+    # accept-non-empty makes Enter a no-op unless something is highlighted, so
+    # that free text cannot leak through this picker. --no-print-query guards
+    # against a --print-query in $FZF_DEFAULT_OPTS, which would otherwise add
+    # the typed query as an extra line and break the parsing.
+    proc = _run_fzf(
+        choices,
+        "--bind=enter:accept-non-empty",
+        "--no-print-query",
+        "--prompt=issue> ",
+        "--header=Select an open issue.",
+    )
+    return parse_fzf_issue(proc.returncode, proc.stdout)
+
+
+def _largest_brace_span(text: str) -> str:
+    """Return the substring from the first ``{`` to the last ``}``, if any."""
+    start, end = text.find("{"), text.rfind("}")
+    return text[start : end + 1] if 0 <= start < end else ""
+
+
+def extract_secure_url(stdout: str) -> str:
+    """Extract the ``secure_url`` from the output of ``cld uploader upload``.
+
+    The Cloudinary CLI pretty-prints the raw API response as JSON, so parsing
+    the whole output is the primary path. The fallbacks are there because the
+    exact format is an implementation detail of the CLI that has changed across
+    versions: older ones colorize the JSON even when the output is captured,
+    and a future one may prepend progress information.
+
+    :param stdout: The standard output of ``cld uploader upload``.
+    """
+    text = ANSI_ESCAPE.sub("", stdout).strip()
+    if not text:
+        raise ValueError(
+            "`cld uploader upload` produced no output; the upload probably failed."
+        )
+    for candidate in (text, _largest_brace_span(text)):
+        if not candidate:
+            continue
+        try:
+            data = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        url = data.get("secure_url", "") if isinstance(data, dict) else ""
+        if url:
+            return url
+        # Fall through rather than give up: a response that parses but carries
+        # no top-level `secure_url` (a wrapped or list payload, say) is exactly
+        # the kind of variation the scraping below is here to absorb.
+    if match := SECURE_URL.search(text):
+        return match.group("url")
+    if match := CLOUDINARY_URL.search(text):
+        return match.group().rstrip('",')
+    raise ValueError(
+        f"Could not find the uploaded image URL in the output of cld:\n{text[:1000]}"
+    )
+
+
+def build_cld_command(image: Path, folder: str, tags: Sequence[str]) -> list[str]:
+    """Build the ``cld uploader upload`` command.
+
+    The upload options are passed as ``key=value`` positionals. Note that the
+    quotes in a shell example such as ``tags="a,b"`` are shell quoting only:
+    nothing here runs through a shell, so quoting the value would make the
+    quotes part of the first and last tag.
+
+    :param image: The local image to upload.
+    :param folder: The Cloudinary folder to upload into.
+    :param tags: Tags to attach to the uploaded image.
+    """
+    cmd = ["cld", "uploader", "upload", str(image), f"folder={folder}"]
+    if tags:
+        cmd.append("tags=" + ",".join(tags))
+    return cmd
+
+
+def upload_image(image: Path, folder: str, tags: Sequence[str]) -> str:
+    """Upload a local image to Cloudinary and return its URL.
+
+    :param image: The local image to upload.
+    :param folder: The Cloudinary folder to upload into.
+    :param tags: Tags to attach to the uploaded image.
+    """
+    if not image.is_file():
+        raise FileNotFoundError(f"The image file '{image}' does not exist.")
+    if not shutil.which("cld"):
+        raise FileNotFoundError(
+            "The Cloudinary CLI (cld) is not installed but is needed to upload "
+            "a local image. Install it, or pass --image-url instead."
+        )
+    # check=True is avoided on purpose: it would raise a CalledProcessError
+    # whose message drops stderr, which is exactly where Cloudinary explains
+    # what went wrong.
+    proc = sp.run(
+        build_cld_command(image.resolve(), folder, tags),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Failed to upload '{image}' to Cloudinary (exit {proc.returncode}): "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    return extract_secure_url(proc.stdout)
+
+
+def parse_args(args=None, namespace=None) -> Namespace:
+    """Parse command line arguments.
+
+    :param args: The arguments to parse. Defaults to the command line ones.
+    :param namespace: An object to take the parsed attributes.
+    :return: The parsed arguments.
+    """
+    parser = RedactingArgumentParser(
+        description="Upload an image and post it as a new comment on a GitHub issue."
+    )
+    parser.add_argument(
+        # No short option on purpose: -t next to -T for --issue-title would
+        # make a case slip post the token as a public issue title.
+        "--token",
+        dest="token",
+        default="",
+        help="The personal access token for authentication. "
+        "If not specified, the GITHUB_TOKEN environment variable is used.",
+    )
+    parser.add_argument(
+        "-r",
+        "--repo",
+        dest="repo",
+        default="",
+        help="The GitHub repository (of the format owner/repo) to comment on. "
+        f"If not specified, one of {', '.join(POPULAR_REPOS)} is selected using "
+        "fzf, where any other repository can also be typed in freely.",
+    )
+    # Not required: with neither of the two specified, an open issue is picked
+    # interactively instead.
+    group_issue = parser.add_mutually_exclusive_group()
+    group_issue.add_argument(
+        "-n",
+        "--issue-number",
+        dest="issue_number",
+        type=int,
+        default=0,
+        help="The number of an existing issue to comment on. "
+        "If neither this nor --issue-title is specified, "
+        "an open issue is selected using fzf.",
+    )
+    group_issue.add_argument(
+        "-T",
+        "--issue-title",
+        dest="issue_title",
+        # None rather than "" so that an explicitly empty title is told apart
+        # from an absent one and rejected instead of opening the issue picker.
+        default=None,
+        help="The title of a new issue to create and comment on.",
+    )
+    # Required: there is no way to guess which image is meant.
+    group_image = parser.add_mutually_exclusive_group(required=True)
+    group_image.add_argument(
+        "-p",
+        "--image-path",
+        "--image",
+        dest="image_path",
+        default="",
+        help="The path of a local image, which is uploaded to Cloudinary "
+        "using the Cloudinary CLI (cld).",
+    )
+    group_image.add_argument(
+        "-u",
+        "--image-url",
+        dest="image_url",
+        default="",
+        help="The URL of an already uploaded image, which is referenced as is.",
+    )
+    parser.add_argument(
+        "-g", "--tags", dest="tags", nargs="*", default=[], help=TAGS_HELP
+    )
+    parser.add_argument(
+        "-a",
+        "--alt",
+        dest="alt",
+        default="",
+        help="Alt text of the image. Defaults to the name of the image.",
+    )
+    parser.add_argument(
+        "-b",
+        "--body",
+        dest="body",
+        default="",
+        help="Text to place above the image in the comment.",
+    )
+    return parser.parse_args(args=args, namespace=namespace)
+
+
+def upload_image_to_issue(
+    token: str,
+    repo: str,
+    issue_number: int,
+    issue_title: str | None,
+    image_path: str,
+    image_url: str,
+    tags: Sequence[str],
+    alt: str,
+    body: str,
+) -> int:
+    """Post an image as a new comment on a GitHub issue and return its number.
+
+    The image is uploaded before an issue is created so that a failed upload
+    does not leave an empty issue behind, and every interactive step happens
+    before anything is created so that a cancelled picker does not leave an
+    unreferenced image on Cloudinary.
+
+    :param token: The personal access token for authentication.
+    :param repo: The GitHub repository (of the format owner/repo) to comment on.
+        If empty, it is selected interactively.
+    :param issue_number: The number of an existing issue to comment on.
+    :param issue_title: The title of a new issue to create and comment on.
+        Used only if no issue number is specified.
+    :param image_path: The path of a local image to upload to Cloudinary.
+    :param image_url: The URL of an already uploaded image.
+        Takes precedence over the local image.
+    :param tags: Tags to attach to the uploaded image.
+    :param alt: Alt text of the image. Defaults to the name of the image.
+    :param body: Text to place above the image in the comment.
+    :raises ValueError: If no image, an empty issue title, or a value that
+        looks like a GitHub token is specified.
+    :raises RuntimeError: If an issue was created but could not be commented
+        on, in which case the message carries the number of that issue.
+    """
+    # Checked before anything is uploaded, created or even authenticated, so
+    # that a misplaced token never reaches GitHub or Cloudinary.
+    for option, value in (
+        ("--repo", repo),
+        ("--issue-title", issue_title or ""),
+        ("--image-path", image_path),
+        ("--image-url", image_url),
+        ("--alt", alt),
+        ("--body", body),
+        *(("--tags", tag) for tag in tags),
+    ):
+        reject_github_token(option, value)
+    # An option given as an empty string satisfies its mutually exclusive group
+    # and would otherwise be silently treated as absent, taking a branch the
+    # user did not ask for.
+    if not image_path.strip() and not image_url.strip():
+        raise ValueError("--image-path and --image-url must not be empty.")
+    if issue_title is not None and not issue_title.strip():
+        raise ValueError("--issue-title must not be empty.")
+    token = resolve_github_token(token)
+    repo = repo.strip() or select_repo()
+    # The picker accepts free text, so a repository typed there has not
+    # been through the check above.
+    reject_github_token("--repo", repo)
+    validate_repo(repo)
+    repository = Repository(token=token, repo=repo)
+    if not issue_number and not issue_title:
+        issue_number = select_issue(repository)
+    url = image_url.strip() or upload_image(
+        Path(image_path), folder=cloudinary_folder(repo), tags=tags
+    )
+    created = not issue_number
+    if created:
+        issue_number = repository.create_issue(title=str(issue_title))["number"]
+    try:
+        repository.create_issue_comment_image(
+            issue_number, url, alt=alt or Path(image_path or url).name, body=body
+        )
+    except Exception as e:
+        if created:
+            # The issue exists but holds no image, and its number has not been
+            # reported yet, so without this a retry would just create a second
+            # empty issue.
+            raise RuntimeError(
+                f"Created issue #{issue_number} but failed to comment on it: {e}. "
+                f"Retry with --issue-number {issue_number}."
+            ) from e
+        raise
+    return issue_number
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        issue_number = upload_image_to_issue(
+            token=args.token,
+            repo=args.repo,
+            issue_number=args.issue_number,
+            issue_title=args.issue_title,
+            image_path=args.image_path,
+            image_url=args.image_url,
+            tags=parse_tags(args.tags),
+            alt=args.alt,
+            body=args.body,
+        )
+    except Exception as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    # The bare number is the only thing on stdout so that it can be captured
+    # with a command substitution and reused.
+    print(issue_number)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/github_rest_api/scripts/github/upload_image_to_issue.py
+++ b/github_rest_api/scripts/github/upload_image_to_issue.py
@@ -12,13 +12,18 @@ import re
 import shutil
 import subprocess as sp
 import sys
-from argparse import ArgumentParser, Namespace
+from argparse import Namespace
 from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import Any
 
 from github_rest_api import IssueState, Repository
-from github_rest_api.scripts.utils import resolve_github_token, validate_repo
+from github_rest_api.scripts.utils import (
+    RedactingArgumentParser,
+    reject_github_token,
+    resolve_github_token,
+    validate_repo,
+)
 from github_rest_api.utils import as_str_sequence
 
 POPULAR_REPOS = ("dclong/tasks", "legendu-net/blog")
@@ -27,12 +32,6 @@ POPULAR_REPOS = ("dclong/tasks", "legendu-net/blog")
 FZF_EXIT_NO_MATCH = 1
 FZF_EXIT_ERROR = 2
 FZF_EXIT_ABORT = 130
-# The prefixed GitHub token formats: gh[pousr]_ for the classic ones and
-# github_pat_ for fine-grained ones. The trailing lengths are open ended
-# because GitHub reserves the right to grow tokens up to 255 characters, and
-# the prefix plus 20+ alphanumerics is already specific enough that ordinary
-# prose cannot trip it.
-GITHUB_TOKEN = re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{22,}")
 ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
 SECURE_URL = re.compile(r'"secure_url"\s*:\s*"(?P<url>[^"]+)"')
 CLOUDINARY_URL = re.compile(r"https://res\.cloudinary\.com/\S+")
@@ -67,41 +66,6 @@ def parse_tags(tags: str | Sequence[str]) -> list[str]:
             if part and part not in result:
                 result.append(part)
     return result
-
-
-class RedactingArgumentParser(ArgumentParser):
-    """An ``ArgumentParser`` that keeps GitHub tokens out of its own errors.
-
-    argparse quotes the offending value back at the user for an unrecognized
-    option or a bad type, so ``-t <token>`` -- the very slip that dropping the
-    short ``-t`` is meant to catch -- would print the token to stderr.
-    """
-
-    def error(self, message: str) -> NoReturn:
-        super().error(GITHUB_TOKEN.sub("<redacted>", message))
-
-
-def reject_github_token(option: str, value: str) -> None:
-    """Refuse a value that looks like a GitHub token.
-
-    Only ``--token`` is meant to carry one. Everything else this script accepts
-    ends up somewhere public: an issue title, a comment body, an image tag. A
-    token mistyped into one of those is disclosed to everyone who can read the
-    repository, so it is rejected rather than sent.
-
-    The offending value is deliberately kept out of the error message, which
-    would otherwise copy the token into logs and terminal scrollback.
-
-    :param option: The name of the option the value came from, for the message.
-    :param value: The value to check.
-    :raises ValueError: If the value contains something shaped like a token.
-    """
-    if GITHUB_TOKEN.search(value):
-        raise ValueError(
-            f"The value passed to {option} looks like a GitHub token. Pass a "
-            "token with --token or $GITHUB_TOKEN instead. If it is a real "
-            "token, revoke it: it is already in your shell history."
-        )
 
 
 def cloudinary_folder(repo: str) -> str:

--- a/github_rest_api/scripts/utils.py
+++ b/github_rest_api/scripts/utils.py
@@ -3,15 +3,60 @@
 import getpass
 import os
 import random
+import re
 import tomllib
+from argparse import ArgumentParser
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, NoReturn
 
 from dulwich import porcelain
 from dulwich.repo import Repo
 
 from github_rest_api.utils import as_str_sequence
+
+# The prefixed GitHub token formats: gh[pousr]_ for the classic ones and
+# github_pat_ for fine-grained ones. The trailing lengths are open ended
+# because GitHub reserves the right to grow tokens up to 255 characters, and
+# the prefix plus 20+ alphanumerics is already specific enough that ordinary
+# prose cannot trip it. Legacy 40-hex tokens are deliberately not matched:
+# they are indistinguishable from a commit SHA.
+GITHUB_TOKEN = re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{22,}")
+
+
+class RedactingArgumentParser(ArgumentParser):
+    """An ``ArgumentParser`` that keeps GitHub tokens out of its own errors.
+
+    argparse quotes the offending value back at the user for an unrecognized
+    option or a bad type, which would print to stderr a token that was typed
+    into the wrong option.
+    """
+
+    def error(self, message: str) -> NoReturn:
+        super().error(GITHUB_TOKEN.sub("<redacted>", message))
+
+
+def reject_github_token(option: str, value: str) -> None:
+    """Refuse a value that looks like a GitHub token.
+
+    Only a token option is meant to carry one. Values of other options tend to
+    end up somewhere public -- an issue title, a comment body, a release name --
+    where a mistyped token is disclosed to everyone who can read the
+    repository, so it is rejected rather than sent.
+
+    The offending value is deliberately kept out of the error message, which
+    would otherwise copy the token into logs and terminal scrollback.
+
+    :param option: The name of the option the value came from, for the message.
+    :param value: The value to check.
+    :raises ValueError: If the value contains something shaped like a token.
+    """
+    if GITHUB_TOKEN.search(value):
+        raise ValueError(
+            f"The value passed to {option} looks like a GitHub token. Pass a "
+            "token with --token or $GITHUB_TOKEN instead. If it is a real "
+            "token, revoke it: it is already in your shell history."
+        )
 
 
 def resolve_github_token(token: str = "") -> str:

--- a/github_rest_api/scripts/utils.py
+++ b/github_rest_api/scripts/utils.py
@@ -1,5 +1,7 @@
 """Util functions for GitHub actions."""
 
+import getpass
+import os
 import random
 import tomllib
 from collections.abc import Sequence
@@ -10,6 +12,35 @@ from dulwich import porcelain
 from dulwich.repo import Repo
 
 from github_rest_api.utils import as_str_sequence
+
+
+def resolve_github_token(token: str = "") -> str:
+    """Resolve a GitHub token from the argument, the environment or a prompt.
+
+    :param token: An explicitly provided token, which takes precedence.
+        When empty, the ``GITHUB_TOKEN`` environment variable is used, and
+        failing that the token is asked for interactively.
+    :raises ValueError: If no token is available from any of the 3 sources.
+    """
+    token = token or os.getenv("GITHUB_TOKEN", "")
+    if not token:
+        token = getpass.getpass("Please enter your GitHub token: ")
+        if not token:
+            raise ValueError(
+                "No GitHub token is provided (via $GITHUB_TOKEN, --token or at prompt)."
+            )
+    return token
+
+
+def validate_repo(repo: str) -> None:
+    """Check that a repository is of the form ``owner/repo``.
+
+    :param repo: The GitHub repository to validate.
+    :raises ValueError: If the repository is not of the form ``owner/repo``.
+    """
+    parts = repo.split("/")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError(f"Invalid repo format '{repo}'. Expected 'owner/repo'.")
 
 
 def config_git(local_repo_dir: str | Path, user_email: str, user_name: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,11 @@ version = "0.49.0"
 description = "Simple wrapper of GitHub REST APIs."
 readme = "README.md"
 authors = [ { name = "Ben Du", email = "longendu@yahoo.com" } ]
-requires-python = ">=3.12,<4"
+# 3.12.7 rather than 3.12: earlier patch releases decide whether a required
+# mutually exclusive argparse group was satisfied by comparing the parsed value
+# against the default with `is`, so an explicitly empty option is mistaken for
+# an absent one.
+requires-python = ">=3.12.7,<4"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ scripts.create_pull_request = "github_rest_api.scripts.github.create_pull_reques
 scripts.release_on_github = "github_rest_api.scripts.github.release_on_github:main"
 scripts.remove_branch = "github_rest_api.scripts.github.remove_branch:main"
 scripts.update_version_containerfile = "github_rest_api.scripts.container.update_version_containerfile:main"
+scripts.upload_image_to_issue = "github_rest_api.scripts.github.upload_image_to_issue:main"
 
 [dependency-groups]
 dev = [

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -215,6 +215,74 @@ def test_create_issue_comment_reaches_requests_post():
     assert mock_post.call_args.kwargs["json"] == {"body": "a comment"}
 
 
+def test_create_issue_comment_image_builds_markdown():
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "create_issue_comment") as mock_comment:
+        repo.create_issue_comment_image(7, "https://h.test/a.png", alt="a shot")
+    assert mock_comment.call_args.args == (7, "![a shot](<https://h.test/a.png>)")
+
+
+def test_create_issue_comment_image_defaults_to_empty_alt():
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "create_issue_comment") as mock_comment:
+        repo.create_issue_comment_image(7, "https://h.test/a.png")
+    assert mock_comment.call_args.args == (7, "![](<https://h.test/a.png>)")
+
+
+def test_create_issue_comment_image_places_body_above_image():
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "create_issue_comment") as mock_comment:
+        repo.create_issue_comment_image(7, "https://h.test/a.png", body="See below.")
+    assert mock_comment.call_args.args == (
+        7,
+        "See below.\n\n![](<https://h.test/a.png>)",
+    )
+
+
+def test_create_issue_comment_image_url_with_space_stays_intact():
+    """The angle brackets are what keep such a URL from ending the link early."""
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "create_issue_comment") as mock_comment:
+        repo.create_issue_comment_image(7, "https://h.test/shot (1).png")
+    assert mock_comment.call_args.args == (7, "![](<https://h.test/shot (1).png>)")
+
+
+def test_create_issue_comment_image_escapes_brackets_in_alt():
+    """An unescaped bracket closes the label and kills the image silently."""
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "create_issue_comment") as mock_comment:
+        repo.create_issue_comment_image(7, "https://h.test/a.png", alt="chart [v2]")
+    assert mock_comment.call_args.args == (
+        7,
+        "![chart \\[v2\\]](<https://h.test/a.png>)",
+    )
+
+
+def test_create_issue_comment_image_escapes_backslash_in_alt_first():
+    """A literal backslash must not turn into an escape for the next character.
+
+    The alt text needs both a backslash and a bracket to pin the ordering:
+    without the bracket, escaping in either order yields the same string.
+    """
+    repo = Repository("token", "owner/name")
+    with patch.object(repo, "create_issue_comment") as mock_comment:
+        repo.create_issue_comment_image(7, "https://h.test/a.png", alt="a\\[b")
+    assert mock_comment.call_args.args == (7, "![a\\\\\\[b](<https://h.test/a.png>)")
+
+
+def test_create_issue_comment_image_reaches_requests_post():
+    """See `test_create_issue_reaches_requests_post` for why this layer."""
+    repo = Repository("token", "owner/name")
+    with patch("github_rest_api.github.requests.post") as mock_post:
+        repo.create_issue_comment_image(7, "https://h.test/a.png", alt="a shot")
+    assert mock_post.call_args.kwargs["url"] == (
+        "https://api.github.com/repos/owner/name/issues/7/comments"
+    )
+    assert mock_post.call_args.kwargs["json"] == {
+        "body": "![a shot](<https://h.test/a.png>)"
+    }
+
+
 def test_create_issue_passes_milestone():
     repo = Repository("token", "owner/name")
     with patch.object(repo, "_post", return_value=MagicMock()) as mock_post:

--- a/tests/test_release_on_github.py
+++ b/tests/test_release_on_github.py
@@ -3,9 +3,14 @@ from unittest.mock import patch
 
 import pytest
 
-from github_rest_api.scripts.github.release_on_github import _get_release_tag
+from github_rest_api.scripts.github import release_on_github as module
+from github_rest_api.scripts.github.release_on_github import (
+    _get_release_tag,
+    parse_args,
+)
 
 ROOT = Path(".")
+TOKEN = "ghp_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"
 
 
 def test_tag_already_normalized():
@@ -62,3 +67,55 @@ def test_prerelease_tag():
 
 def test_build_metadata_tag():
     assert _get_release_tag("1.2.3+build", ROOT) == "v1.2.3+build"
+
+
+def test_tag_holding_a_token_is_refused_before_it_is_echoed():
+    """-t is the tag here, not the token, so this slip is easy to make."""
+    with pytest.raises(ValueError, match="looks like a GitHub token") as excinfo:
+        _get_release_tag(TOKEN, ROOT)
+    # The semver failure would otherwise quote the tag back at the user.
+    assert TOKEN not in str(excinfo.value)
+
+
+def test_tag_holding_a_token_is_refused_even_without_validation():
+    """--no-validate skips the semver check, so it cannot be the only guard."""
+    with pytest.raises(ValueError, match="looks like a GitHub token"):
+        _get_release_tag(TOKEN, ROOT, validate=False)
+
+
+def test_release_refuses_a_token_in_the_branch():
+    with patch.object(module, "Repository") as repository:
+        with pytest.raises(ValueError, match="looks like a GitHub token"):
+            module.release_on_github(token="", branch=TOKEN)
+    repository.assert_not_called()
+
+
+def test_release_refuses_a_token_in_the_notes():
+    with patch.object(module, "Repository") as repository:
+        with pytest.raises(ValueError, match="looks like a GitHub token"):
+            module.release_on_github(token="", branch="main", notes=TOKEN)
+    repository.assert_not_called()
+
+
+def test_parse_args_has_no_short_option_for_the_tag(capsys):
+    """-t reads as the token, and the tag becomes the public release name."""
+    with pytest.raises(SystemExit):
+        parse_args(["-t", "v1.2.3"])
+    assert parse_args(["--tag", "v1.2.3"]).tag == "v1.2.3"
+
+
+def test_parse_args_redacts_a_token_passed_to_the_removed_short_option(capsys):
+    """The slip this removal targets must not print the token either."""
+    with pytest.raises(SystemExit):
+        parse_args(["-t", TOKEN])
+    err = capsys.readouterr().err
+    assert TOKEN not in err
+    assert "<redacted>" in err
+
+
+def test_parse_args_redacts_a_token_from_argparse_errors(capsys):
+    with pytest.raises(SystemExit):
+        parse_args(["--bogus", TOKEN])
+    err = capsys.readouterr().err
+    assert TOKEN not in err
+    assert "<redacted>" in err

--- a/tests/test_upload_image_to_issue.py
+++ b/tests/test_upload_image_to_issue.py
@@ -1,0 +1,625 @@
+import json
+import subprocess as sp
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from github_rest_api import IssueState
+from github_rest_api.scripts.github import upload_image_to_issue as module
+from github_rest_api.scripts.github.upload_image_to_issue import (
+    build_cld_command,
+    cloudinary_folder,
+    extract_secure_url,
+    issue_choices,
+    parse_args,
+    parse_fzf_issue,
+    parse_fzf_repo,
+    parse_tags,
+)
+
+URL = "https://res.cloudinary.com/demo/image/upload/v1/tasks/a.png"
+
+
+def test_parse_tags_splits_on_commas():
+    assert parse_tags(["a,b,c"]) == ["a", "b", "c"]
+
+
+def test_parse_tags_keeps_space_delimited_values():
+    assert parse_tags(["a", "b", "c"]) == ["a", "b", "c"]
+
+
+def test_parse_tags_mixes_both_delimiters():
+    assert parse_tags(["a, b", "c"]) == ["a", "b", "c"]
+
+
+def test_parse_tags_accepts_a_bare_string():
+    """`as_str_sequence` keeps a bare string from exploding into characters."""
+    assert parse_tags("a,b") == ["a", "b"]
+
+
+def test_parse_tags_drops_empty_parts_and_duplicates():
+    assert parse_tags(["a,,b", " ", "b", "a"]) == ["a", "b"]
+
+
+def test_parse_tags_keeps_spaces_inside_a_tag():
+    """A quoted value is one tag, so that 'my son' survives as written."""
+    assert parse_tags(["my son", "beach"]) == ["my son", "beach"]
+
+
+def test_parse_tags_splits_a_comma_separated_tag_with_spaces():
+    assert parse_tags(["my son, my daughter"]) == ["my son", "my daughter"]
+
+
+def test_parse_tags_of_nothing_is_empty():
+    assert parse_tags([]) == []
+
+
+CLASSIC_TOKEN = "ghp_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"
+FINE_GRAINED_TOKEN = "github_pat_" + "A1b2C3d4E5f6G7h8I9j0K1" + "_" + "z" * 59
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        CLASSIC_TOKEN,
+        FINE_GRAINED_TOKEN,
+        CLASSIC_TOKEN.replace("ghp_", "gho_"),
+        CLASSIC_TOKEN.replace("ghp_", "ghu_"),
+        CLASSIC_TOKEN.replace("ghp_", "ghs_"),
+        CLASSIC_TOKEN.replace("ghp_", "ghr_"),
+        f"my token is {CLASSIC_TOKEN} ok",
+    ],
+)
+def test_reject_github_token_catches_every_token_format(value):
+    with pytest.raises(ValueError, match="looks like a GitHub token"):
+        module.reject_github_token("--body", value)
+
+
+def test_reject_github_token_keeps_the_value_out_of_the_message():
+    """The message reaches stderr and logs, so it must not carry the secret."""
+    with pytest.raises(ValueError) as excinfo:
+        module.reject_github_token("--body", CLASSIC_TOKEN)
+    assert CLASSIC_TOKEN not in str(excinfo.value)
+    assert "--body" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "a normal issue title",
+        "ghp_short",
+        "see github_pat for details",
+        "https://res.cloudinary.com/demo/image/upload/v1/tasks/a.png",
+        "fix the ghp_ prefix handling",
+        # A legacy 40-hex PAT is indistinguishable from a commit SHA, and
+        # SHAs are common in issue bodies, so that format is deliberately
+        # not covered.
+        "regressed in 8007e96f5537e85d23fadc389f353e2b4a96614a",
+    ],
+)
+def test_reject_github_token_allows_ordinary_values(value):
+    module.reject_github_token("--body", value)
+
+
+def test_reject_github_token_catches_a_token_glued_to_a_word():
+    """No leading word boundary, so an embedded token is still caught."""
+    with pytest.raises(ValueError, match="looks like a GitHub token"):
+        module.reject_github_token("--body", f"MY_{CLASSIC_TOKEN}")
+
+
+def test_cloudinary_folder_uses_the_repository_name():
+    assert cloudinary_folder("dclong/tasks") == "tasks"
+    assert cloudinary_folder("legendu-net/blog") == "blog"
+
+
+def test_issue_choices_drops_pull_requests():
+    """GitHub's issues endpoint returns pull requests too."""
+    issues = [
+        {"number": 1, "title": "an issue"},
+        {"number": 2, "title": "a PR", "pull_request": {"url": "..."}},
+    ]
+    assert issue_choices(issues) == ["1\tan issue"]
+
+
+def test_issue_choices_squeezes_whitespace_in_titles():
+    """A tab or newline in a title would otherwise break the record layout."""
+    issues = [{"number": 3, "title": "a\tb\nc  d"}]
+    assert issue_choices(issues) == ["3\ta b c d"]
+
+
+def test_issue_choices_of_nothing_is_empty():
+    assert issue_choices([]) == []
+
+
+def test_parse_fzf_repo_prefers_the_selection():
+    assert parse_fzf_repo(0, "das\ndclong/tasks\n") == "dclong/tasks"
+
+
+def test_parse_fzf_repo_falls_back_to_the_query_when_nothing_matched():
+    assert parse_fzf_repo(1, "owner/other\n") == "owner/other"
+
+
+def test_parse_fzf_repo_handles_an_empty_query_line():
+    """Nothing typed, an entry highlighted: the query line is empty."""
+    assert parse_fzf_repo(0, "\ndclong/tasks\n") == "dclong/tasks"
+
+
+def test_parse_fzf_repo_rejects_a_cancelled_picker():
+    with pytest.raises(ValueError, match="cancelled"):
+        parse_fzf_repo(130, "")
+
+
+def test_parse_fzf_repo_rejects_a_blank_query():
+    with pytest.raises(ValueError, match="No repository"):
+        parse_fzf_repo(1, "\n")
+
+
+def test_parse_fzf_issue_takes_the_leading_number():
+    assert parse_fzf_issue(0, "12\ta title\n") == 12
+
+
+def test_parse_fzf_issue_rejects_a_cancelled_picker():
+    with pytest.raises(ValueError, match="cancelled"):
+        parse_fzf_issue(130, "")
+
+
+def test_parse_fzf_issue_rejects_empty_output():
+    with pytest.raises(ValueError, match="No issue"):
+        parse_fzf_issue(0, "")
+
+
+def test_parse_fzf_issue_rejects_a_non_numeric_field():
+    with pytest.raises(ValueError, match="Could not parse"):
+        parse_fzf_issue(0, "oops\ta title")
+
+
+def test_extract_secure_url_parses_json():
+    assert extract_secure_url(json.dumps({"secure_url": URL})) == URL
+
+
+def test_extract_secure_url_strips_ansi_colors():
+    """Older versions of cld colorize the JSON even when it is captured."""
+    assert extract_secure_url(f'\x1b[32m{{"secure_url": "{URL}"}}\x1b[0m') == URL
+
+
+def test_extract_secure_url_ignores_a_leading_log_line():
+    stdout = f'uploading...\n{{"secure_url": "{URL}"}}'
+    assert extract_secure_url(stdout) == URL
+
+
+def test_extract_secure_url_scrapes_the_field_out_of_broken_json():
+    """A non-Cloudinary host keeps this off the CLOUDINARY_URL fallback."""
+    assert (
+        extract_secure_url('{"secure_url": "https://h.test/a.png", truncated')
+        == "https://h.test/a.png"
+    )
+
+
+def test_extract_secure_url_scrapes_a_wrapped_response():
+    """Valid JSON without a top-level secure_url must not end the search."""
+    assert extract_secure_url(json.dumps({"result": {"secure_url": URL}})) == URL
+
+
+def test_extract_secure_url_falls_back_to_any_cloudinary_url():
+    assert extract_secure_url(f"Uploaded to {URL}") == URL
+
+
+def test_extract_secure_url_rejects_a_response_without_the_field():
+    with pytest.raises(ValueError, match="Could not find"):
+        extract_secure_url(json.dumps({"error": "nope"}))
+
+
+def test_extract_secure_url_rejects_empty_output():
+    with pytest.raises(ValueError, match="no output"):
+        extract_secure_url("   ")
+
+
+def test_extract_secure_url_rejects_unparseable_output():
+    with pytest.raises(ValueError, match="Could not find"):
+        extract_secure_url("something went wrong")
+
+
+def test_build_cld_command_passes_folder_and_tags(tmp_path):
+    image = tmp_path / "a.png"
+    assert build_cld_command(image, "tasks", ["x", "y"]) == [
+        "cld",
+        "uploader",
+        "upload",
+        str(image),
+        "folder=tasks",
+        "tags=x,y",
+    ]
+
+
+def test_build_cld_command_omits_tags_when_there_are_none(tmp_path):
+    assert "tags=" not in " ".join(build_cld_command(tmp_path / "a.png", "tasks", []))
+
+
+def test_build_cld_command_does_not_quote_tags(tmp_path):
+    """There is no shell involved, so a quote would become part of a tag."""
+    cmd = build_cld_command(tmp_path / "a.png", "tasks", ["x", "y"])
+    assert '"' not in "".join(cmd)
+
+
+def test_parse_args_requires_an_image():
+    with pytest.raises(SystemExit):
+        parse_args([])
+
+
+def test_parse_args_rejects_two_image_sources():
+    with pytest.raises(SystemExit):
+        parse_args(["--image-path", "a.png", "--image-url", URL])
+
+
+def test_parse_args_rejects_two_issue_sources():
+    with pytest.raises(SystemExit):
+        parse_args(["--image-url", URL, "--issue-number", "1", "--issue-title", "t"])
+
+
+def test_parse_args_defaults_to_no_issue():
+    args = parse_args(["--image-url", URL])
+    assert args.issue_number == 0
+    assert args.issue_title is None
+
+
+def test_parse_args_accepts_short_options():
+    args = parse_args(
+        ["-r", "o/n", "-n", "7", "-u", URL, "-g", "x,y", "-a", "A", "-b", "B"]
+    )
+    assert (args.repo, args.issue_number) == ("o/n", 7)
+    assert (args.image_url, args.tags, args.alt, args.body) == (URL, ["x,y"], "A", "B")
+
+
+@pytest.mark.parametrize("option", ["-p", "--image-path", "--image"])
+def test_parse_args_accepts_every_spelling_of_the_image_path(option):
+    """--image stays usable, and being explicit keeps it from being ambiguous."""
+    assert parse_args([option, "a.png"]).image_path == "a.png"
+
+
+def test_parse_args_short_issue_title():
+    args = parse_args(["-T", "a title", "-p", "a.png"])
+    assert args.issue_title == "a title"
+    assert args.image_path == "a.png"
+
+
+def test_parse_args_has_no_short_option_for_the_token():
+    """-t next to -T would let a case slip post the token as an issue title."""
+    with pytest.raises(SystemExit):
+        parse_args(["-t", "tk", "-u", URL])
+    assert parse_args(["--token", "tk", "-u", URL]).token == "tk"
+
+
+def test_select_repo_allows_free_text_entry():
+    """--print-query is what makes a repository outside the list reachable."""
+    proc = sp.CompletedProcess([], returncode=1, stdout="owner/other\n", stderr="")
+    with patch.object(module, "_run_fzf", return_value=proc) as mock:
+        assert module.select_repo() == "owner/other"
+    options = mock.call_args.args[1:]
+    assert mock.call_args.args[0] == module.POPULAR_REPOS
+    assert "--print-query" in options
+    assert "--exact" in options
+
+
+def test_select_issue_offers_open_issues_only_and_forbids_free_text():
+    repository = MagicMock()
+    repository.get_issues.return_value = [
+        {"number": 5, "title": "an issue"},
+        {"number": 6, "title": "a PR", "pull_request": {}},
+    ]
+    proc = sp.CompletedProcess([], returncode=0, stdout="5\tan issue\n", stderr="")
+    with patch.object(module, "_run_fzf", return_value=proc) as mock:
+        assert module.select_issue(repository) == 5
+    assert repository.get_issues.call_args.kwargs == {"state": IssueState.OPEN}
+    assert mock.call_args.args[0] == ["5\tan issue"]
+    options = mock.call_args.args[1:]
+    assert "--bind=enter:accept-non-empty" in options
+    assert "--no-print-query" in options
+
+
+def test_select_issue_reports_when_there_is_nothing_to_select():
+    """Better than dropping the user into an empty picker."""
+    repository = MagicMock()
+    repository.get_issues.return_value = []
+    with patch.object(module, "_run_fzf") as mock:
+        with pytest.raises(ValueError, match="no open issue"):
+            module.select_issue(repository)
+    mock.assert_not_called()
+
+
+def test_upload_image_rejects_a_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        module.upload_image(tmp_path / "nope.png", "tasks", [])
+
+
+def test_upload_image_reports_a_missing_cld(tmp_path):
+    image = tmp_path / "a.png"
+    image.touch()
+    with patch.object(module.shutil, "which", return_value=None):
+        with pytest.raises(FileNotFoundError, match="Cloudinary CLI"):
+            module.upload_image(image, "tasks", [])
+
+
+def test_upload_image_surfaces_stderr_on_failure(tmp_path):
+    """`check=True` would swallow the message Cloudinary actually sent."""
+    image = tmp_path / "a.png"
+    image.touch()
+    proc = sp.CompletedProcess([], returncode=1, stdout="", stderr="invalid api key")
+    with patch.object(module.shutil, "which", return_value="/usr/bin/cld"):
+        with patch.object(module.sp, "run", return_value=proc):
+            with pytest.raises(RuntimeError, match="invalid api key"):
+                module.upload_image(image, "tasks", [])
+
+
+def _run_main(monkeypatch, argv, repository=None):
+    """Drive `main` with a mocked `Repository` and return it with the exit code."""
+    repository = repository or MagicMock()
+    # Without a token in the environment, the resolution would fall through to
+    # an interactive prompt and hang the test run.
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(sys, "argv", ["upload_image_to_issue", *argv])
+    with patch.object(module, "Repository", return_value=repository):
+        code = module.main()
+    return repository, code
+
+
+def test_main_comments_on_an_existing_issue(monkeypatch, capsys):
+    repository, code = _run_main(
+        monkeypatch,
+        ["--repo", "dclong/tasks", "--issue-number", "7", "--image-url", URL],
+    )
+    assert code == 0
+    repository.create_issue_comment_image.assert_called_once()
+    assert repository.create_issue_comment_image.call_args.args == (7, URL)
+    repository.create_issue.assert_not_called()
+    # The bare number, so that it can be captured and reused.
+    assert capsys.readouterr().out == "7\n"
+
+
+def test_main_creates_an_issue_and_prints_its_number(monkeypatch, capsys):
+    repository = MagicMock()
+    repository.create_issue.return_value = {"number": 42}
+    _, code = _run_main(
+        monkeypatch,
+        ["--repo", "dclong/tasks", "--issue-title", "a title", "--image-url", URL],
+        repository,
+    )
+    assert code == 0
+    assert repository.create_issue.call_args.kwargs == {"title": "a title"}
+    assert repository.create_issue_comment_image.call_args.args == (42, URL)
+    assert capsys.readouterr().out == "42\n"
+
+
+def test_main_selects_a_repository_when_none_is_given(monkeypatch):
+    with patch.object(module, "select_repo", return_value="legendu-net/blog") as mock:
+        repository, code = _run_main(
+            monkeypatch, ["--issue-number", "7", "--image-url", URL]
+        )
+    assert code == 0
+    mock.assert_called_once()
+    assert repository.create_issue_comment_image.call_args.args == (7, URL)
+
+
+def test_main_selects_an_issue_when_none_is_given(monkeypatch):
+    with patch.object(module, "select_issue", return_value=9) as mock:
+        repository, code = _run_main(
+            monkeypatch, ["--repo", "dclong/tasks", "--image-url", URL]
+        )
+    assert code == 0
+    mock.assert_called_once()
+    assert repository.create_issue_comment_image.call_args.args == (9, URL)
+
+
+def test_main_uploads_a_local_image_into_the_repository_folder(monkeypatch):
+    with patch.object(module, "upload_image", return_value=URL) as mock:
+        repository, code = _run_main(
+            monkeypatch,
+            [
+                "--repo",
+                "legendu-net/blog",
+                "--issue-number",
+                "7",
+                "--image-path",
+                "/tmp/a.png",
+                "--tags",
+                "x,y",
+                "z",
+            ],
+        )
+    assert code == 0
+    assert mock.call_args.kwargs == {"folder": "blog", "tags": ["x", "y", "z"]}
+    assert repository.create_issue_comment_image.call_args.args == (7, URL)
+
+
+def test_main_defaults_alt_to_the_image_name(monkeypatch):
+    with patch.object(module, "upload_image", return_value=URL):
+        repository, _ = _run_main(
+            monkeypatch,
+            [
+                "--repo",
+                "dclong/tasks",
+                "--issue-number",
+                "7",
+                "--image-path",
+                "/tmp/shot.png",
+            ],
+        )
+    assert repository.create_issue_comment_image.call_args.kwargs["alt"] == "shot.png"
+
+
+def test_main_does_not_create_an_issue_when_the_upload_fails(monkeypatch, capsys):
+    """A failed upload must not leave an empty issue behind."""
+    with patch.object(module, "upload_image", side_effect=RuntimeError("upload boom")):
+        repository, code = _run_main(
+            monkeypatch,
+            [
+                "--repo",
+                "dclong/tasks",
+                "--issue-title",
+                "a title",
+                "--image-path",
+                "/tmp/a.png",
+            ],
+        )
+    assert code == 1
+    repository.create_issue.assert_not_called()
+    repository.create_issue_comment_image.assert_not_called()
+    assert "upload boom" in capsys.readouterr().err
+
+
+def test_main_reports_a_failure_on_stderr(monkeypatch, capsys):
+    with patch.object(module, "select_issue", side_effect=ValueError("no open issue")):
+        _, code = _run_main(monkeypatch, ["--repo", "dclong/tasks", "--image-url", URL])
+    assert code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "no open issue" in captured.err
+
+
+def test_main_reports_the_issue_number_when_commenting_fails(monkeypatch, capsys):
+    """A retry must be able to reuse the issue instead of creating a second one."""
+    repository = MagicMock()
+    repository.create_issue.return_value = {"number": 42}
+    repository.create_issue_comment_image.side_effect = RuntimeError("502")
+    _, code = _run_main(
+        monkeypatch,
+        ["--repo", "dclong/tasks", "--issue-title", "a title", "--image-url", URL],
+        repository,
+    )
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "Created issue #42" in err
+    assert "--issue-number 42" in err
+    # The original cause must survive into the message, not be swallowed.
+    assert "502" in err
+
+
+def test_main_does_not_claim_to_have_created_an_existing_issue(monkeypatch, capsys):
+    """The failure of a comment on --issue-number must not be reported as a creation."""
+    repository = MagicMock()
+    repository.create_issue_comment_image.side_effect = RuntimeError("403")
+    _, code = _run_main(
+        monkeypatch,
+        ["--repo", "dclong/tasks", "--issue-number", "7", "--image-url", URL],
+        repository,
+    )
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "403" in err
+    assert "Created issue" not in err
+
+
+def test_main_does_not_upload_when_the_issue_picker_is_cancelled(monkeypatch):
+    """Otherwise an image is left on Cloudinary that nothing ever references."""
+    with patch.object(module, "select_issue", side_effect=ValueError("cancelled")):
+        with patch.object(module, "upload_image") as mock:
+            _, code = _run_main(
+                monkeypatch, ["--repo", "dclong/tasks", "--image-path", "/tmp/a.png"]
+            )
+    assert code == 1
+    mock.assert_not_called()
+
+
+@pytest.mark.parametrize("image_url", ["", "   "])
+def test_main_rejects_a_blank_image_url(monkeypatch, capsys, image_url):
+    """An empty value satisfies the group but names no image."""
+    repository, code = _run_main(
+        monkeypatch,
+        ["--repo", "dclong/tasks", "--issue-number", "7", "--image-url", image_url],
+    )
+    assert code == 1
+    repository.create_issue_comment_image.assert_not_called()
+    assert "must not be empty" in capsys.readouterr().err
+
+
+def test_main_rejects_a_blank_issue_title(monkeypatch, capsys):
+    """Otherwise this silently opens the issue picker instead."""
+    with patch.object(module, "select_issue") as mock:
+        repository, code = _run_main(
+            monkeypatch,
+            ["--repo", "dclong/tasks", "--issue-title", "", "--image-url", URL],
+        )
+    assert code == 1
+    mock.assert_not_called()
+    repository.create_issue.assert_not_called()
+    assert "must not be empty" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--issue-title", CLASSIC_TOKEN, "--image-url", URL],
+        ["--issue-number", "7", "--body", CLASSIC_TOKEN, "--image-url", URL],
+        ["--issue-number", "7", "--alt", CLASSIC_TOKEN, "--image-url", URL],
+        ["--issue-number", "7", "--image-path", CLASSIC_TOKEN],
+        ["--issue-number", "7", "--image-url", CLASSIC_TOKEN],
+        ["--issue-number", "7", "--tags", "ok", CLASSIC_TOKEN, "--image-url", URL],
+    ],
+)
+def test_main_refuses_a_token_passed_to_another_option(monkeypatch, capsys, argv):
+    """A token in any of these would be published where others can read it."""
+    with patch.object(module, "upload_image") as upload:
+        repository, code = _run_main(monkeypatch, ["--repo", "dclong/tasks", *argv])
+    assert code == 1
+    upload.assert_not_called()
+    repository.create_issue.assert_not_called()
+    repository.create_issue_comment_image.assert_not_called()
+    err = capsys.readouterr().err
+    assert "looks like a GitHub token" in err
+    assert CLASSIC_TOKEN not in err
+
+
+def test_main_refuses_a_token_in_the_repository(monkeypatch, capsys):
+    """Caught before validate_repo, which would echo the value verbatim."""
+    with patch.object(module, "validate_repo") as validate:
+        _, code = _run_main(
+            monkeypatch,
+            ["--repo", CLASSIC_TOKEN, "--issue-number", "7", "--image-url", URL],
+        )
+    assert code == 1
+    validate.assert_not_called()
+    err = capsys.readouterr().err
+    assert "looks like a GitHub token" in err
+    assert CLASSIC_TOKEN not in err
+
+
+def test_main_refuses_a_token_typed_into_the_repository_picker(monkeypatch, capsys):
+    """The picker takes free text, so its result needs the check too."""
+    with patch.object(module, "select_repo", return_value=f"me/{CLASSIC_TOKEN}"):
+        with patch.object(module, "upload_image") as upload:
+            repository, code = _run_main(
+                monkeypatch, ["--issue-number", "7", "--image-url", URL]
+            )
+    assert code == 1
+    upload.assert_not_called()
+    repository.create_issue_comment_image.assert_not_called()
+    err = capsys.readouterr().err
+    assert "looks like a GitHub token" in err
+    assert CLASSIC_TOKEN not in err
+
+
+def test_parse_args_redacts_a_token_from_argparse_errors(capsys):
+    """argparse quotes the bad value back, which would print the token."""
+    with pytest.raises(SystemExit):
+        parse_args(["-t", CLASSIC_TOKEN, "--image-url", URL])
+    err = capsys.readouterr().err
+    assert CLASSIC_TOKEN not in err
+    assert "<redacted>" in err
+
+
+def test_parse_args_redacts_a_token_from_a_bad_int_value(capsys):
+    with pytest.raises(SystemExit):
+        parse_args(["--issue-number", CLASSIC_TOKEN, "--image-url", URL])
+    err = capsys.readouterr().err
+    assert CLASSIC_TOKEN not in err
+    assert "<redacted>" in err
+
+
+def test_main_rejects_a_malformed_repository(monkeypatch, capsys):
+    repository, code = _run_main(
+        monkeypatch, ["--repo", "tasks", "--issue-number", "7", "--image-url", URL]
+    )
+    assert code == 1
+    repository.create_issue_comment_image.assert_not_called()
+    assert "Invalid repo format" in capsys.readouterr().err

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,46 @@
+from unittest.mock import patch
+
 import pytest
 
+from github_rest_api.scripts.utils import resolve_github_token, validate_repo
 from github_rest_api.utils import (
     as_str_sequence,
     next_minor_or_strip_patch,
     strip_patch_version,
 )
+
+
+def test_resolve_github_token_prefers_the_explicit_token(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "from_env")
+    assert resolve_github_token("explicit") == "explicit"
+
+
+def test_resolve_github_token_falls_back_to_the_environment(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "from_env")
+    assert resolve_github_token() == "from_env"
+
+
+def test_resolve_github_token_falls_back_to_a_prompt(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    with patch("github_rest_api.scripts.utils.getpass.getpass", return_value="typed"):
+        assert resolve_github_token() == "typed"
+
+
+def test_resolve_github_token_rejects_an_empty_prompt(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    with patch("github_rest_api.scripts.utils.getpass.getpass", return_value=""):
+        with pytest.raises(ValueError, match="No GitHub token"):
+            resolve_github_token()
+
+
+@pytest.mark.parametrize("repo", ["tasks", "a/b/c", "/b", "a/", ""])
+def test_validate_repo_rejects_malformed_repositories(repo):
+    with pytest.raises(ValueError, match="Invalid repo format"):
+        validate_repo(repo)
+
+
+def test_validate_repo_accepts_owner_slash_repo():
+    validate_repo("dclong/tasks")
 
 
 def test_as_str_sequence_wraps_bare_string():

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.12, <4"
+requires-python = ">=3.12.7, <4"
 
 [[package]]
 name = "aiohappyeyeballs"


### PR DESCRIPTION
## Summary

- feat: add create_issue_comment_image method for posting images in issue comments
- feat: add upload_image_to_issue script and extract token/repo utilities
- refactor: extract token validation utilities to utils module

## Changed files

**Added**
- `github_rest_api/scripts/github/upload_image_to_issue.py` (+505/-0)
- `tests/test_upload_image_to_issue.py` (+625/-0)
**Modified**
- `github_rest_api/github.py` (+26/-0)
- `github_rest_api/scripts/github/create_github_repo.py` (+3/-16)
- `github_rest_api/scripts/github/release_on_github.py` (+16/-12)
- `github_rest_api/scripts/utils.py` (+77/-1)
- `pyproject.toml` (+1/-0)
- `tests/test_github.py` (+68/-0)
- `tests/test_release_on_github.py` (+58/-1)
- `tests/test_utils.py` (+36/-0)

## Commits

- 8007e96 feat: add create_issue_comment_image method for posting images in issue comments
- 2fb9789 feat: add upload_image_to_issue script and extract token/repo utilities
- 3441971 refactor: extract token validation utilities to utils module