### PR TITLE
feat: add progress logging for key operations

### DIFF
--- a/github_rest_api/scripts/github/upload_image_to_issue.py
+++ b/github_rest_api/scripts/github/upload_image_to_issue.py
@@ -8,6 +8,7 @@ environment variables.
 """
 
 import json
+import logging
 import re
 import shutil
 import subprocess as sp
@@ -25,6 +26,8 @@ from github_rest_api.scripts.utils import (
     validate_repo,
 )
 from github_rest_api.utils import as_str_sequence
+
+logger = logging.getLogger(__name__)
 
 POPULAR_REPOS = ("dclong/tasks", "legendu-net/blog")
 # fzf reports both "nothing matched the query" and "the user walked away" through
@@ -66,6 +69,17 @@ def parse_tags(tags: str | Sequence[str]) -> list[str]:
             if part and part not in result:
                 result.append(part)
     return result
+
+
+def _link(response: dict[str, Any]) -> str:
+    """Render the web link of a created issue or comment for a log message.
+
+    :param response: An issue or comment as returned by the GitHub API. GitHub
+        always carries an ``html_url``, but a message reading ``Created issue
+        #7: `` would look truncated if one ever did not.
+    """
+    url = response.get("html_url", "")
+    return f": {url}" if url else "."
 
 
 def cloudinary_folder(repo: str) -> str:
@@ -287,6 +301,12 @@ def upload_image(image: Path, folder: str, tags: Sequence[str]) -> str:
             "The Cloudinary CLI (cld) is not installed but is needed to upload "
             "a local image. Install it, or pass --image-url instead."
         )
+    logger.info(
+        "Uploading '%s' to the Cloudinary folder '%s'%s ...",
+        image,
+        folder,
+        f" with tags {', '.join(tags)}" if tags else "",
+    )
     # check=True is avoided on purpose: it would raise a CalledProcessError
     # whose message drops stderr, which is exactly where Cloudinary explains
     # what went wrong.
@@ -301,7 +321,9 @@ def upload_image(image: Path, folder: str, tags: Sequence[str]) -> str:
             f"Failed to upload '{image}' to Cloudinary (exit {proc.returncode}): "
             f"{proc.stderr.strip() or proc.stdout.strip()}"
         )
-    return extract_secure_url(proc.stdout)
+    url = extract_secure_url(proc.stdout)
+    logger.info("Uploaded the image to %s", url)
+    return url
 
 
 def parse_args(args=None, namespace=None) -> Namespace:
@@ -460,9 +482,13 @@ def upload_image_to_issue(
     )
     created = not issue_number
     if created:
-        issue_number = repository.create_issue(title=str(issue_title))["number"]
+        logger.info("Creating issue '%s' in %s ...", issue_title, repo)
+        issue = repository.create_issue(title=str(issue_title))
+        issue_number = issue["number"]
+        logger.info("Created issue #%s%s", issue_number, _link(issue))
+    logger.info("Commenting on issue #%s of %s ...", issue_number, repo)
     try:
-        repository.create_issue_comment_image(
+        comment = repository.create_issue_comment_image(
             issue_number, url, alt=alt or Path(image_path or url).name, body=body
         )
     except Exception as e:
@@ -475,11 +501,16 @@ def upload_image_to_issue(
                 f"Retry with --issue-number {issue_number}."
             ) from e
         raise
+    logger.info("Posted the comment%s", _link(comment))
     return issue_number
 
 
 def main() -> int:
     args = parse_args()
+    # The progress messages are emitted through logging, which the root logger
+    # would otherwise suppress. They go to stderr, leaving stdout to the issue
+    # number alone.
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
     try:
         issue_number = upload_image_to_issue(
             token=args.token,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "github-rest-api"
-version = "0.49.0"
+version = "0.50.0"
 description = "Simple wrapper of GitHub REST APIs."
 readme = "README.md"
 authors = [ { name = "Ben Du", email = "longendu@yahoo.com" } ]

--- a/tests/test_upload_image_to_issue.py
+++ b/tests/test_upload_image_to_issue.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import subprocess as sp
 import sys
 from unittest.mock import MagicMock, patch
@@ -352,6 +353,20 @@ def test_upload_image_surfaces_stderr_on_failure(tmp_path):
                 module.upload_image(image, "tasks", [])
 
 
+def test_upload_image_reports_the_upload(tmp_path, caplog):
+    """The upload is the slow step, so it must not look like a hang."""
+    image = tmp_path / "a.png"
+    image.touch()
+    proc = sp.CompletedProcess([], returncode=0, stdout=json.dumps({"secure_url": URL}))
+    with patch.object(module.shutil, "which", return_value="/usr/bin/cld"):
+        with patch.object(module.sp, "run", return_value=proc):
+            with caplog.at_level(logging.INFO, logger=module.__name__):
+                module.upload_image(image, "tasks", ["x", "y"])
+    assert f"Uploading '{image}' to the Cloudinary folder 'tasks'" in caplog.text
+    assert "with tags x, y" in caplog.text
+    assert f"Uploaded the image to {URL}" in caplog.text
+
+
 def _run_main(monkeypatch, argv, repository=None):
     """Drive `main` with a mocked `Repository` and return it with the exit code."""
     repository = repository or MagicMock()
@@ -508,6 +523,66 @@ def test_main_does_not_claim_to_have_created_an_existing_issue(monkeypatch, caps
     err = capsys.readouterr().err
     assert "403" in err
     assert "Created issue" not in err
+
+
+def test_main_reports_the_created_issue(monkeypatch, caplog):
+    """Progress goes to the log, so that stdout stays the issue number alone."""
+    repository = MagicMock()
+    repository.create_issue.return_value = {
+        "number": 42,
+        "html_url": "https://github.com/dclong/tasks/issues/42",
+    }
+    with caplog.at_level(logging.INFO, logger=module.__name__):
+        _run_main(
+            monkeypatch,
+            ["--repo", "dclong/tasks", "--issue-title", "a title", "--image-url", URL],
+            repository,
+        )
+    assert "Creating issue 'a title' in dclong/tasks" in caplog.text
+    assert "Created issue #42: https://github.com/dclong/tasks/issues/42" in caplog.text
+
+
+def test_main_reports_a_created_issue_without_a_link(monkeypatch, caplog):
+    """A response without an html_url must not log a message that looks cut off."""
+    repository = MagicMock()
+    repository.create_issue.return_value = {"number": 42}
+    with caplog.at_level(logging.INFO, logger=module.__name__):
+        _run_main(
+            monkeypatch,
+            ["--repo", "dclong/tasks", "--issue-title", "a title", "--image-url", URL],
+            repository,
+        )
+    assert "Created issue #42." in caplog.text
+
+
+def test_main_keeps_the_log_off_stdout(monkeypatch):
+    """Stdout carries the issue number alone, so the progress has to go elsewhere.
+
+    Asserting on captured stdout cannot catch this: under pytest the root
+    logger already has handlers, which makes `basicConfig` a no-op.
+    """
+    with patch.object(module.logging, "basicConfig") as mock:
+        _run_main(
+            monkeypatch,
+            ["--repo", "dclong/tasks", "--issue-number", "7", "--image-url", URL],
+        )
+    # Neither a stream nor a handler, which is a `StreamHandler` on stderr.
+    assert mock.call_args.kwargs == {"level": logging.INFO, "format": "%(message)s"}
+
+
+def test_main_reports_the_posted_comment(monkeypatch, caplog):
+    repository = MagicMock()
+    repository.create_issue_comment_image.return_value = {
+        "html_url": "https://github.com/dclong/tasks/issues/7#issuecomment-1"
+    }
+    with caplog.at_level(logging.INFO, logger=module.__name__):
+        _run_main(
+            monkeypatch,
+            ["--repo", "dclong/tasks", "--issue-number", "7", "--image-url", URL],
+            repository,
+        )
+    assert "Commenting on issue #7 of dclong/tasks" in caplog.text
+    assert "issuecomment-1" in caplog.text
 
 
 def test_main_does_not_upload_when_the_issue_picker_is_cancelled(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -542,7 +542,7 @@ wheels = [
 
 [[package]]
 name = "github-rest-api"
-version = "0.49.0"
+version = "0.50.0"
 source = { editable = "." }
 dependencies = [
     { name = "dulwich" },


### PR DESCRIPTION
## Summary

- feat(upload-image-to-issue): add progress logging for key operations

## Changed files

**Modified**
- `github_rest_api/scripts/github/upload_image_to_issue.py` (+34/-3)
- `pyproject.toml` (+1/-1)
- `tests/test_upload_image_to_issue.py` (+75/-0)
- `uv.lock` (+1/-1)

## Commits

- 0080100 feat(upload-image-to-issue): add progress logging for key operations